### PR TITLE
feat: add use, set-priority, init, and swap commands for manual account switching, priority-based rotation, and credential hot-swap

### DIFF
--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -577,7 +577,7 @@ async function cmdRun(claudeArgs) {
       }
     }
 
-    const best = pickBestAccount(withUsage);
+    const best = pickBestAccount(withUsage, undefined, { usePriority: true });
 
     if (best) {
       selectedAccount = best.account;
@@ -717,7 +717,7 @@ async function cmdResume(resumeArgs) {
       }
     }
 
-    const best = pickBestAccount(withUsage);
+    const best = pickBestAccount(withUsage, undefined, { usePriority: true });
 
     if (best) {
       selectedAccount = best.account;

--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -894,13 +894,35 @@ async function cmdSwap(swapArgs) {
 
   if (!targetName) {
     console.error('Usage: claude-nonstop swap <account>');
+    console.error('       claude-nonstop swap --restore');
     console.error('');
     console.error('Hot-swaps credentials into the currently active config directory.');
     console.error('Running Claude Code sessions will pick up the new credentials');
     console.error('on their next API call — no restart needed.');
     console.error('');
+    console.error('Use --restore to put back the original credentials.');
+    console.error('');
     console.error('Example: claude-nonstop swap main');
     process.exit(1);
+  }
+
+  const activeConfigDir = process.env.CLAUDE_CONFIG_DIR || DEFAULT_CLAUDE_DIR;
+  const activeCredFile = join(activeConfigDir, '.credentials.json');
+  const backupCredFile = join(activeConfigDir, '.credentials.json.backup');
+
+  // --restore: put back the original credentials
+  if (targetName === '--restore') {
+    if (!existsSync(backupCredFile)) {
+      console.error('No backup found. Nothing to restore.');
+      process.exit(1);
+    }
+    const backupData = readFileSync(backupCredFile, 'utf-8');
+    const tmpFile = `${activeCredFile}.${process.pid}.${Date.now()}.tmp`;
+    writeFileSync(tmpFile, backupData, { mode: 0o600 });
+    renameSync(tmpFile, activeCredFile);
+    console.log('Restored original credentials from backup.');
+    console.log('Running sessions will use the original credentials on next API call.');
+    return;
   }
 
   const accounts = getAccounts();
@@ -912,8 +934,6 @@ async function cmdSwap(swapArgs) {
     process.exit(1);
   }
 
-  // Determine which config dir is currently active
-  const activeConfigDir = process.env.CLAUDE_CONFIG_DIR || DEFAULT_CLAUDE_DIR;
   const activeAccount = accounts.find(a => a.configDir === activeConfigDir);
   const activeLabel = activeAccount ? activeAccount.name : 'unknown';
 
@@ -929,17 +949,20 @@ async function cmdSwap(swapArgs) {
     process.exit(1);
   }
 
-  // Read the raw credentials file from the target
   const targetCredFile = join(target.configDir, '.credentials.json');
   if (!existsSync(targetCredFile)) {
     console.error(`Error: Credentials file not found for "${targetName}".`);
     process.exit(1);
   }
 
-  const credData = readFileSync(targetCredFile, 'utf-8');
+  // Back up current credentials (only if no backup exists — preserve the original)
+  if (existsSync(activeCredFile) && !existsSync(backupCredFile)) {
+    const currentData = readFileSync(activeCredFile, 'utf-8');
+    writeFileSync(backupCredFile, currentData, { mode: 0o600 });
+  }
 
-  // Write into the active config dir's credentials file (atomic)
-  const activeCredFile = join(activeConfigDir, '.credentials.json');
+  // Write target credentials into the active config dir (atomic)
+  const credData = readFileSync(targetCredFile, 'utf-8');
   const tmpFile = `${activeCredFile}.${process.pid}.${Date.now()}.tmp`;
   writeFileSync(tmpFile, credData, { mode: 0o600 });
   renameSync(tmpFile, activeCredFile);
@@ -947,6 +970,8 @@ async function cmdSwap(swapArgs) {
   console.log(`Swapped credentials: "${activeLabel}" → "${targetName}"`);
   console.log(`Active config dir: ${activeConfigDir}`);
   console.log('Running sessions will use the new credentials on next API call.');
+  console.log('');
+  console.log('To restore original: claude-nonstop swap --restore');
 }
 
 // ─── Init (shell integration) ───────────────────────────────────────────────

--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -763,7 +763,9 @@ async function cmdUse(useArgs) {
 
   // --unset — revert to default
   if (flag === '--unset') {
+    // stdout: eval-friendly command; stderr: human message
     console.log('unset CLAUDE_CONFIG_DIR');
+    console.error(`Reverted to default account (${DEFAULT_CLAUDE_DIR})`);
     return;
   }
 
@@ -789,8 +791,8 @@ async function cmdUse(useArgs) {
       process.exit(1);
     }
 
-    console.error(`[claude-nonstop] Selected "${best.account.name}" (${best.reason})`);
     console.log(`export CLAUDE_CONFIG_DIR="${best.account.configDir}"`);
+    console.error(`Switched to "${best.account.name}" (${best.reason})`);
     return;
   }
 
@@ -816,8 +818,8 @@ async function cmdUse(useArgs) {
       process.exit(1);
     }
 
-    console.error(`[claude-nonstop] Selected "${best.account.name}" (${best.reason})`);
     console.log(`export CLAUDE_CONFIG_DIR="${best.account.configDir}"`);
+    console.error(`Switched to "${best.account.name}" (${best.reason})`);
     return;
   }
 
@@ -838,6 +840,7 @@ async function cmdUse(useArgs) {
   }
 
   console.log(`export CLAUDE_CONFIG_DIR="${account.configDir}"`);
+  console.error(`Switched to "${account.name}" (${account.configDir})`);
 }
 
 async function cmdSetPriority(priorityArgs) {
@@ -1554,11 +1557,11 @@ Commands:
   reauth               Re-authenticate expired accounts
   resume [id]          Resume most recent session, or a specific one by ID
   use [name|flag]      Switch active account for current shell (Agent SDK, etc.)
-                         use <name>       Explicit account
-                         use --best       Lowest utilization (ignores priority)
-                         use --priority   Highest priority under 98% usage
-                         use --unset      Revert to default ~/.claude
-                         use              Show current active account
+                         eval $(claude-nonstop use <name>)       Explicit account
+                         eval $(claude-nonstop use --best)       Lowest utilization (ignores priority)
+                         eval $(claude-nonstop use --priority)   Highest priority under 98% usage
+                         eval $(claude-nonstop use --unset)      Revert to default ~/.claude
+                         claude-nonstop use                      Show current active account
   set-priority <name> <n>  Set account priority (1 = highest). Use "clear" to remove.
   setup                Configure Slack remote access
   webhook              Webhook service management

--- a/lib/config.js
+++ b/lib/config.js
@@ -117,6 +117,41 @@ export function removeAccount(name) {
 }
 
 /**
+ * Set priority for an account. Lower number = higher priority.
+ *
+ * @param {string} name - Account name
+ * @param {number} priority - Positive integer (1 = highest priority)
+ */
+export function setAccountPriority(name, priority) {
+  if (!Number.isInteger(priority) || priority < 1) {
+    throw new Error('Priority must be a positive integer (1 = highest)');
+  }
+
+  const config = loadConfig();
+  const account = config.accounts.find(a => a.name === name);
+
+  if (!account) throw new Error(`Account "${name}" not found`);
+
+  account.priority = priority;
+  saveConfig(config);
+}
+
+/**
+ * Remove priority from an account (reverts to unranked).
+ *
+ * @param {string} name - Account name
+ */
+export function clearAccountPriority(name) {
+  const config = loadConfig();
+  const account = config.accounts.find(a => a.name === name);
+
+  if (!account) throw new Error(`Account "${name}" not found`);
+
+  delete account.priority;
+  saveConfig(config);
+}
+
+/**
  * Get all registered accounts.
  */
 export function getAccounts() {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -246,7 +246,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
     })).filter(a => a.token);
 
     let accountsWithUsage = await checkAllUsage(accountsWithTokens);
-    let best = pickBestAccount(accountsWithUsage, currentAccount.name);
+    let best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: true });
 
     // If best candidate is near-exhausted, sleep until earliest reset instead of thrashing.
     // Include all accounts (even current) when finding reset times — after sleeping,
@@ -290,7 +290,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
           token: readCredentials(a.configDir).token,
         })).filter(a => a.token);
         accountsWithUsage = await checkAllUsage(refreshedTokens);
-        best = pickBestAccount(accountsWithUsage);
+        best = pickBestAccount(accountsWithUsage, undefined, { usePriority: true });
 
         if (remoteAccess) {
           spawnHookNotify('sleep-wake', {
@@ -322,7 +322,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
             token: readCredentials(a.configDir).token,
           })).filter(a => a.token);
           accountsWithUsage = await checkAllUsage(updatedAccounts);
-          best = pickBestAccount(accountsWithUsage, currentAccount.name);
+          best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: true });
         }
       }
     }

--- a/lib/scorer.js
+++ b/lib/scorer.js
@@ -4,16 +4,24 @@
  * Picks the best account based on usage — lowest effective utilization wins.
  * Effective utilization = max(sessionPercent, weeklyPercent) so we avoid
  * accounts that are near either limit.
+ *
+ * When usePriority is true, accounts with lower priority numbers are preferred
+ * over accounts with lower utilization. Accounts at or above 98% utilization
+ * are considered "near-exhausted" and skipped in favor of the next priority.
  */
+
+const PRIORITY_THRESHOLD = 98;
 
 /**
  * Pick the best account from a list of accounts with usage data.
  *
- * @param {Array<{name: string, configDir: string, token: string, usage: object}>} accounts
+ * @param {Array<{name: string, configDir: string, token: string, usage: object, priority?: number}>} accounts
  * @param {string} [excludeName] - Account name to exclude (e.g., the one that just hit a limit)
+ * @param {object} [options]
+ * @param {boolean} [options.usePriority=false] - When true, prefer accounts by priority number
  * @returns {{ account: object, reason: string } | null}
  */
-export function pickBestAccount(accounts, excludeName) {
+export function pickBestAccount(accounts, excludeName, options = {}) {
   const candidates = accounts.filter(a => {
     if (a.name === excludeName) return false;
     if (!a.token) return false;
@@ -23,7 +31,39 @@ export function pickBestAccount(accounts, excludeName) {
 
   if (candidates.length === 0) return null;
 
-  // Sort by effective utilization (ascending — lowest usage first)
+  if (options.usePriority) {
+    // Priority-aware sorting:
+    // 1. Non-exhausted (< 98%) before exhausted (>= 98%)
+    // 2. Within each group: lower priority number first (nulls last)
+    // 3. Tiebreaker: lower utilization first
+    candidates.sort((a, b) => {
+      const aUtil = effectiveUtilization(a.usage);
+      const bUtil = effectiveUtilization(b.usage);
+      const aExhausted = aUtil >= PRIORITY_THRESHOLD;
+      const bExhausted = bUtil >= PRIORITY_THRESHOLD;
+
+      // Non-exhausted accounts always come first
+      if (aExhausted !== bExhausted) return aExhausted ? 1 : -1;
+
+      // Within same exhaustion group: sort by priority (lower = better, null = last)
+      const aPri = a.priority ?? Infinity;
+      const bPri = b.priority ?? Infinity;
+      if (aPri !== bPri) return aPri - bPri;
+
+      // Same priority: sort by utilization
+      return aUtil - bUtil;
+    });
+
+    const best = candidates[0];
+    const pri = best.priority != null ? `, priority: ${best.priority}` : '';
+
+    return {
+      account: best,
+      reason: `priority selection (session: ${best.usage.sessionPercent}%, weekly: ${best.usage.weeklyPercent}%${pri})`,
+    };
+  }
+
+  // Default: sort by effective utilization (ascending — lowest usage first)
   candidates.sort((a, b) => {
     const aUtil = effectiveUtilization(a.usage);
     const bUtil = effectiveUtilization(b.usage);
@@ -39,6 +79,17 @@ export function pickBestAccount(accounts, excludeName) {
 }
 
 /**
+ * Pick the best account using priority hierarchy.
+ * Convenience wrapper for `use --priority`.
+ *
+ * @param {Array} accounts - Accounts with usage data
+ * @returns {{ account: object, reason: string } | null}
+ */
+export function pickByPriority(accounts) {
+  return pickBestAccount(accounts, undefined, { usePriority: true });
+}
+
+/**
  * Calculate effective utilization — the higher of session or weekly.
  */
 export function effectiveUtilization(usage) {
@@ -46,3 +97,4 @@ export function effectiveUtilization(usage) {
   return Math.max(usage.sessionPercent || 0, usage.weeklyPercent || 0);
 }
 
+export { PRIORITY_THRESHOLD };


### PR DESCRIPTION
## Summary

Adds four new commands for manual account control and credential management:

- **`use <name>`** — manually switch `CLAUDE_CONFIG_DIR` for terminal/Agent SDK use. Supports `--best` (lowest utilization), `--priority` (priority-based), and `--unset` modes.
- **`set-priority <name> <number>`** — assign priority ranking to accounts (1 = highest). Auto-rotation now prefers higher-priority accounts and proactively rotates at 98% usage before hitting the 100% wall.
- **`init <shell>`** — shell integration (like conda/nvm) so `claude-nonstop use <name>` sets env directly without manual `eval`. Add `eval "$(claude-nonstop init bash)"` to `~/.bashrc`.
- **`swap <name>`** — hot-swap credentials into the active config directory for running sessions. Claude Code re-reads credentials on each API call, so no restart needed. Includes `--restore` to put back original credentials (automatic backup on first swap).

### Changes

- **`bin/claude-nonstop.js`** — Added `use`, `set-priority`, `init`, `swap` commands. Updated `run`/`resume` to use priority-based selection. Updated `list`/`status` to show priority labels.
- **`lib/config.js`** — Added `setAccountPriority()` and `clearAccountPriority()` functions.
- **`lib/scorer.js`** — Added `usePriority` option to `pickBestAccount()`, `pickByPriority()` helper, and `PRIORITY_THRESHOLD=98` for proactive rotation.
- **`lib/runner.js`** — All `pickBestAccount()` calls now pass `{ usePriority: true }`.
- **`test/unit/lib/config.test.js`** — 10 new tests for priority set/clear/validation.
- **`test/unit/lib/scorer.test.js`** — 12 new tests for priority sorting, threshold, and `pickByPriority`.

### Priority sorting logic

1. Non-exhausted accounts (<98% utilization) come first
2. Sort by priority ascending (accounts without priority treated as lowest)
3. Tie-break by lowest utilization

All 63 unit tests pass (config + scorer).

## Test plan

- [x] `claude-nonstop use` — shows current account
- [x] `claude-nonstop use <name>` — outputs `export CLAUDE_CONFIG_DIR=...`
- [x] `claude-nonstop use --best` / `--priority` — selects correct account
- [x] `claude-nonstop set-priority <name> <n>` — persists to config
- [x] `claude-nonstop status` — shows priority labels
- [x] `claude-nonstop run` — uses priority-based initial selection
- [x] `claude-nonstop swap <name>` — overwrites active credentials, creates backup
- [x] `claude-nonstop swap --restore` — restores original credentials from backup
- [x] `claude-nonstop init bash` — outputs shell function wrapper
- [x] All 63 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)