### PR TITLE
feat: add use, init, and set-priority commands with priority-aware account selection

### DIFF
--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -581,7 +581,9 @@ async function cmdRun(claudeArgs) {
       }
     }
 
-    const best = pickBestAccount(withUsage, undefined, { usePriority: true });
+    // Only use priority sorting when at least one account has a priority set
+    const hasPriorities = withUsage.some(a => a.priority != null);
+    const best = pickBestAccount(withUsage, undefined, { usePriority: hasPriorities });
 
     if (best) {
       selectedAccount = best.account;
@@ -721,7 +723,8 @@ async function cmdResume(resumeArgs) {
       }
     }
 
-    const best = pickBestAccount(withUsage, undefined, { usePriority: true });
+    const hasPriorities = withUsage.some(a => a.priority != null);
+    const best = pickBestAccount(withUsage, undefined, { usePriority: hasPriorities });
 
     if (best) {
       selectedAccount = best.account;
@@ -795,7 +798,7 @@ async function cmdUse(useArgs) {
       process.exit(1);
     }
 
-    console.log(`export CLAUDE_CONFIG_DIR="${best.account.configDir}"`);
+    console.log(`export CLAUDE_CONFIG_DIR='${best.account.configDir}'`);
     console.error(`Switched to "${best.account.name}" (${best.reason})`);
     return;
   }
@@ -822,7 +825,7 @@ async function cmdUse(useArgs) {
       process.exit(1);
     }
 
-    console.log(`export CLAUDE_CONFIG_DIR="${best.account.configDir}"`);
+    console.log(`export CLAUDE_CONFIG_DIR='${best.account.configDir}'`);
     console.error(`Switched to "${best.account.name}" (${best.reason})`);
     return;
   }
@@ -843,7 +846,7 @@ async function cmdUse(useArgs) {
     console.error(`Warning: Account "${name}" is not authenticated. Run "claude-nonstop reauth" first.`);
   }
 
-  console.log(`export CLAUDE_CONFIG_DIR="${account.configDir}"`);
+  console.log(`export CLAUDE_CONFIG_DIR='${account.configDir}'`);
   console.error(`Switched to "${account.name}" (${account.configDir})`);
 }
 

--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -577,7 +577,7 @@ async function cmdRun(claudeArgs) {
       }
     }
 
-    const best = pickBestAccount(withUsage);
+    const best = pickBestAccount(withUsage, undefined, { usePriority: true });
 
     if (best) {
       selectedAccount = best.account;
@@ -717,7 +717,7 @@ async function cmdResume(resumeArgs) {
       }
     }
 
-    const best = pickBestAccount(withUsage);
+    const best = pickBestAccount(withUsage, undefined, { usePriority: true });
 
     if (best) {
       selectedAccount = best.account;

--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -763,7 +763,9 @@ async function cmdUse(useArgs) {
 
   // --unset — revert to default
   if (flag === '--unset') {
+    // stdout: eval-friendly command; stderr: human message
     console.log('unset CLAUDE_CONFIG_DIR');
+    console.error(`Reverted to default account (${DEFAULT_CLAUDE_DIR})`);
     return;
   }
 
@@ -789,8 +791,8 @@ async function cmdUse(useArgs) {
       process.exit(1);
     }
 
-    console.error(`[claude-nonstop] Selected "${best.account.name}" (${best.reason})`);
     console.log(`export CLAUDE_CONFIG_DIR="${best.account.configDir}"`);
+    console.error(`Switched to "${best.account.name}" (${best.reason})`);
     return;
   }
 
@@ -816,8 +818,8 @@ async function cmdUse(useArgs) {
       process.exit(1);
     }
 
-    console.error(`[claude-nonstop] Selected "${best.account.name}" (${best.reason})`);
     console.log(`export CLAUDE_CONFIG_DIR="${best.account.configDir}"`);
+    console.error(`Switched to "${best.account.name}" (${best.reason})`);
     return;
   }
 
@@ -838,6 +840,7 @@ async function cmdUse(useArgs) {
   }
 
   console.log(`export CLAUDE_CONFIG_DIR="${account.configDir}"`);
+  console.error(`Switched to "${account.name}" (${account.configDir})`);
 }
 
 async function cmdSetPriority(priorityArgs) {
@@ -1554,11 +1557,11 @@ Commands:
   reauth               Re-authenticate expired accounts
   resume [id]          Resume most recent session, or a specific one by ID
   use [name|flag]      Switch active account for current shell (Agent SDK, etc.)
-                         use <name>       Explicit account
-                         use --best       Lowest utilization (ignores priority)
-                         use --priority   Highest priority under 98% usage
-                         use --unset      Revert to default ~/.claude
-                         use              Show current active account
+                         eval $(claude-nonstop use <name>)       Explicit account
+                         eval $(claude-nonstop use --best)       Lowest utilization (ignores priority)
+                         eval $(claude-nonstop use --priority)   Highest priority under 98% usage
+                         eval $(claude-nonstop use --unset)      Revert to default ~/.claude
+                         claude-nonstop use                      Show current active account
   set-priority <name> <n>  Set account priority (1 = highest). Use "clear" to remove.
   setup                Configure Slack remote access
   webhook              Webhook service management

--- a/lib/config.js
+++ b/lib/config.js
@@ -117,6 +117,41 @@ export function removeAccount(name) {
 }
 
 /**
+ * Set priority for an account. Lower number = higher priority.
+ *
+ * @param {string} name - Account name
+ * @param {number} priority - Positive integer (1 = highest priority)
+ */
+export function setAccountPriority(name, priority) {
+  if (!Number.isInteger(priority) || priority < 1) {
+    throw new Error('Priority must be a positive integer (1 = highest)');
+  }
+
+  const config = loadConfig();
+  const account = config.accounts.find(a => a.name === name);
+
+  if (!account) throw new Error(`Account "${name}" not found`);
+
+  account.priority = priority;
+  saveConfig(config);
+}
+
+/**
+ * Remove priority from an account (reverts to unranked).
+ *
+ * @param {string} name - Account name
+ */
+export function clearAccountPriority(name) {
+  const config = loadConfig();
+  const account = config.accounts.find(a => a.name === name);
+
+  if (!account) throw new Error(`Account "${name}" not found`);
+
+  delete account.priority;
+  saveConfig(config);
+}
+
+/**
  * Get all registered accounts.
  */
 export function getAccounts() {

--- a/lib/config.js
+++ b/lib/config.js
@@ -123,6 +123,7 @@ export function removeAccount(name) {
  * @param {number} priority - Positive integer (1 = highest priority)
  */
 export function setAccountPriority(name, priority) {
+  validateAccountName(name);
   if (!Number.isInteger(priority) || priority < 1) {
     throw new Error('Priority must be a positive integer (1 = highest)');
   }
@@ -142,6 +143,7 @@ export function setAccountPriority(name, priority) {
  * @param {string} name - Account name
  */
 export function clearAccountPriority(name) {
+  validateAccountName(name);
   const config = loadConfig();
   const account = config.accounts.find(a => a.name === name);
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -246,7 +246,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
     })).filter(a => a.token);
 
     let accountsWithUsage = await checkAllUsage(accountsWithTokens);
-    let best = pickBestAccount(accountsWithUsage, currentAccount.name);
+    let best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: true });
 
     // If best candidate is near-exhausted, sleep until earliest reset instead of thrashing.
     // Include all accounts (even current) when finding reset times — after sleeping,
@@ -290,7 +290,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
           token: readCredentials(a.configDir).token,
         })).filter(a => a.token);
         accountsWithUsage = await checkAllUsage(refreshedTokens);
-        best = pickBestAccount(accountsWithUsage);
+        best = pickBestAccount(accountsWithUsage, undefined, { usePriority: true });
 
         if (remoteAccess) {
           spawnHookNotify('sleep-wake', {
@@ -322,7 +322,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
             token: readCredentials(a.configDir).token,
           })).filter(a => a.token);
           accountsWithUsage = await checkAllUsage(updatedAccounts);
-          best = pickBestAccount(accountsWithUsage, currentAccount.name);
+          best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: true });
         }
       }
     }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -246,7 +246,8 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
     })).filter(a => a.token);
 
     let accountsWithUsage = await checkAllUsage(accountsWithTokens);
-    let best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: true });
+    const hasPriorities = accountsWithUsage.some(a => a.priority != null);
+    let best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: hasPriorities });
 
     // If best candidate is near-exhausted, sleep until earliest reset instead of thrashing.
     // Include all accounts (even current) when finding reset times — after sleeping,
@@ -290,7 +291,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
           token: readCredentials(a.configDir).token,
         })).filter(a => a.token);
         accountsWithUsage = await checkAllUsage(refreshedTokens);
-        best = pickBestAccount(accountsWithUsage, undefined, { usePriority: true });
+        best = pickBestAccount(accountsWithUsage, undefined, { usePriority: hasPriorities });
 
         if (remoteAccess) {
           spawnHookNotify('sleep-wake', {
@@ -322,7 +323,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
             token: readCredentials(a.configDir).token,
           })).filter(a => a.token);
           accountsWithUsage = await checkAllUsage(updatedAccounts);
-          best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: true });
+          best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: hasPriorities });
         }
       }
     }

--- a/lib/scorer.js
+++ b/lib/scorer.js
@@ -4,16 +4,24 @@
  * Picks the best account based on usage — lowest effective utilization wins.
  * Effective utilization = max(sessionPercent, weeklyPercent) so we avoid
  * accounts that are near either limit.
+ *
+ * When usePriority is true, accounts with lower priority numbers are preferred
+ * over accounts with lower utilization. Accounts at or above 98% utilization
+ * are considered "near-exhausted" and skipped in favor of the next priority.
  */
+
+const PRIORITY_THRESHOLD = 98;
 
 /**
  * Pick the best account from a list of accounts with usage data.
  *
- * @param {Array<{name: string, configDir: string, token: string, usage: object}>} accounts
+ * @param {Array<{name: string, configDir: string, token: string, usage: object, priority?: number}>} accounts
  * @param {string} [excludeName] - Account name to exclude (e.g., the one that just hit a limit)
+ * @param {object} [options]
+ * @param {boolean} [options.usePriority=false] - When true, prefer accounts by priority number
  * @returns {{ account: object, reason: string } | null}
  */
-export function pickBestAccount(accounts, excludeName) {
+export function pickBestAccount(accounts, excludeName, options = {}) {
   const candidates = accounts.filter(a => {
     if (a.name === excludeName) return false;
     if (!a.token) return false;
@@ -23,7 +31,39 @@ export function pickBestAccount(accounts, excludeName) {
 
   if (candidates.length === 0) return null;
 
-  // Sort by effective utilization (ascending — lowest usage first)
+  if (options.usePriority) {
+    // Priority-aware sorting:
+    // 1. Non-exhausted (< 98%) before exhausted (>= 98%)
+    // 2. Within each group: lower priority number first (nulls last)
+    // 3. Tiebreaker: lower utilization first
+    candidates.sort((a, b) => {
+      const aUtil = effectiveUtilization(a.usage);
+      const bUtil = effectiveUtilization(b.usage);
+      const aExhausted = aUtil >= PRIORITY_THRESHOLD;
+      const bExhausted = bUtil >= PRIORITY_THRESHOLD;
+
+      // Non-exhausted accounts always come first
+      if (aExhausted !== bExhausted) return aExhausted ? 1 : -1;
+
+      // Within same exhaustion group: sort by priority (lower = better, null = last)
+      const aPri = a.priority ?? Infinity;
+      const bPri = b.priority ?? Infinity;
+      if (aPri !== bPri) return aPri - bPri;
+
+      // Same priority: sort by utilization
+      return aUtil - bUtil;
+    });
+
+    const best = candidates[0];
+    const pri = best.priority != null ? `, priority: ${best.priority}` : '';
+
+    return {
+      account: best,
+      reason: `priority selection (session: ${best.usage.sessionPercent}%, weekly: ${best.usage.weeklyPercent}%${pri})`,
+    };
+  }
+
+  // Default: sort by effective utilization (ascending — lowest usage first)
   candidates.sort((a, b) => {
     const aUtil = effectiveUtilization(a.usage);
     const bUtil = effectiveUtilization(b.usage);
@@ -39,6 +79,17 @@ export function pickBestAccount(accounts, excludeName) {
 }
 
 /**
+ * Pick the best account using priority hierarchy.
+ * Convenience wrapper for `use --priority`.
+ *
+ * @param {Array} accounts - Accounts with usage data
+ * @returns {{ account: object, reason: string } | null}
+ */
+export function pickByPriority(accounts) {
+  return pickBestAccount(accounts, undefined, { usePriority: true });
+}
+
+/**
  * Calculate effective utilization — the higher of session or weekly.
  */
 export function effectiveUtilization(usage) {
@@ -46,3 +97,4 @@ export function effectiveUtilization(usage) {
   return Math.max(usage.sessionPercent || 0, usage.weeklyPercent || 0);
 }
 
+export { PRIORITY_THRESHOLD };

--- a/test/unit/lib/scorer.test.js
+++ b/test/unit/lib/scorer.test.js
@@ -2,16 +2,17 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { pickBestAccount, pickByPriority, PRIORITY_THRESHOLD } from '../../../lib/scorer.js';
 
+const makeAccount = (name, sessionPercent, weeklyPercent, opts = {}) => ({
+  name,
+  configDir: `/tmp/profiles/${name}`,
+  token: 'token' in opts ? opts.token : 'sk-ant-oat01-valid',
+  priority: opts.priority ?? undefined,
+  usage: opts.error
+    ? { error: opts.error }
+    : { sessionPercent, weeklyPercent },
+});
+
 describe('pickBestAccount', () => {
-  const makeAccount = (name, sessionPercent, weeklyPercent, opts = {}) => ({
-    name,
-    configDir: `/tmp/profiles/${name}`,
-    token: 'token' in opts ? opts.token : 'sk-ant-oat01-valid',
-    priority: opts.priority ?? undefined,
-    usage: opts.error
-      ? { error: opts.error }
-      : { sessionPercent, weeklyPercent },
-  });
 
   it('picks the account with the lowest utilization', () => {
     const accounts = [
@@ -148,16 +149,6 @@ describe('pickBestAccount', () => {
 });
 
 describe('pickBestAccount with usePriority', () => {
-  const makeAccount = (name, sessionPercent, weeklyPercent, opts = {}) => ({
-    name,
-    configDir: `/tmp/profiles/${name}`,
-    token: 'token' in opts ? opts.token : 'sk-ant-oat01-valid',
-    priority: opts.priority ?? undefined,
-    usage: opts.error
-      ? { error: opts.error }
-      : { sessionPercent, weeklyPercent },
-  });
-
   it('picks highest priority account even with higher utilization', () => {
     const accounts = [
       makeAccount('main', 60, 60, { priority: 1 }),     // effective: 60
@@ -241,16 +232,6 @@ describe('pickBestAccount with usePriority', () => {
 });
 
 describe('pickByPriority', () => {
-  const makeAccount = (name, sessionPercent, weeklyPercent, opts = {}) => ({
-    name,
-    configDir: `/tmp/profiles/${name}`,
-    token: 'token' in opts ? opts.token : 'sk-ant-oat01-valid',
-    priority: opts.priority ?? undefined,
-    usage: opts.error
-      ? { error: opts.error }
-      : { sessionPercent, weeklyPercent },
-  });
-
   it('is a convenience wrapper that uses priority', () => {
     const accounts = [
       makeAccount('main', 60, 60, { priority: 1 }),


### PR DESCRIPTION
## Summary

Split from #3 per review feedback. This PR contains the well-designed features with all requested fixes applied:

- **`use <name|--best|--priority|--unset>`** — Manual account switching via `CLAUDE_CONFIG_DIR` export, following the conda/nvm/rbenv pattern
- **`init <bash|zsh>`** — Shell integration with proper stdout/stderr separation for eval-friendly output
- **`set-priority <name> <n>`** — Account priority configuration (lower = preferred)
- **Priority-aware scoring** in `pickBestAccount` — sorts by non-exhausted first → priority → utilization tiebreak

## Fixes from review

- **Shell injection**: Use single quotes in `cmdUse` export output to prevent metacharacter expansion when eval-ed
- **usePriority opt-in**: Priority sorting only activates when at least one account has a priority set, preserving existing selection semantics for users without priorities
- **Input validation**: Added `validateAccountName()` to `setAccountPriority` and `clearAccountPriority`
- **Test cleanup**: Deduplicated `makeAccount` helper in `scorer.test.js` (was defined 3x, now once at module scope)

## Test plan

- [x] All 414 tests pass
- [ ] Verify `use <name>` sets CLAUDE_CONFIG_DIR correctly via `eval "$(claude-nonstop init bash)"`
- [ ] Verify `use --best` picks lowest utilization account
- [ ] Verify `use --priority` respects priority ordering with 98% exhaustion threshold
- [ ] Verify `set-priority` rejects invalid account names
- [ ] Verify priority sorting is inactive when no priorities are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)