### PR TITLE
Add --prefer flag for automatic return to preferred account

### DIFF
--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -477,6 +477,9 @@ async function cmdRun(claudeArgs) {
   // Extract --account / -a flag (consume it, don't pass to claude)
   const requestedAccount = extractAccountFlag(claudeArgs);
 
+  // Extract --prefer / --prefer-threshold flags (consume, don't pass to claude)
+  const { preferredAccount: preferName, preferThreshold } = extractPreferFlags(claudeArgs);
+
   // Handle tmux bootstrapping for remote access
   if (remoteAccess) {
     const { isInsideTmux, generateSessionName, reexecInTmux } = await import('../lib/tmux.js');
@@ -595,8 +598,22 @@ async function cmdRun(claudeArgs) {
     }
   }
 
+  // Validate preferred account if specified
+  if (preferName) {
+    const prefAccount = authenticated.find(a => a.name === preferName);
+    if (!prefAccount) {
+      console.error(`Error: Preferred account "${preferName}" not found or not authenticated.`);
+      console.error(`Authenticated accounts: ${authenticated.map(a => a.name).join(', ')}`);
+      process.exit(1);
+    }
+    console.error(`[claude-nonstop] Preferred account: "${preferName}" (return when session ≤${preferThreshold ?? 30}%)`);
+  }
+
   // Run with auto-switching
-  await run(claudeArgs, selectedAccount, accounts, { remoteAccess });
+  const runOptions = { remoteAccess };
+  if (preferName) runOptions.preferredAccount = preferName;
+  if (preferThreshold != null) runOptions.preferThreshold = preferThreshold;
+  await run(claudeArgs, selectedAccount, accounts, runOptions);
 }
 
 async function cmdResume(resumeArgs) {
@@ -609,6 +626,9 @@ async function cmdResume(resumeArgs) {
 
   // Extract --account / -a flag (consume it, don't pass to claude)
   const requestedAccount = extractAccountFlag(resumeArgs);
+
+  // Extract --prefer / --prefer-threshold flags (consume, don't pass to claude)
+  const { preferredAccount: preferName, preferThreshold } = extractPreferFlags(resumeArgs);
 
   // Handle tmux bootstrapping for remote access
   if (remoteAccess) {
@@ -746,7 +766,21 @@ async function cmdResume(resumeArgs) {
     }
   }
 
-  await run(claudeArgs, selectedAccount, accounts, { remoteAccess });
+  // Validate preferred account if specified
+  if (preferName) {
+    const prefAccount = authenticated.find(a => a.name === preferName);
+    if (!prefAccount) {
+      console.error(`Error: Preferred account "${preferName}" not found or not authenticated.`);
+      console.error(`Authenticated accounts: ${authenticated.map(a => a.name).join(', ')}`);
+      process.exit(1);
+    }
+    console.error(`[claude-nonstop] Preferred account: "${preferName}" (return when session ≤${preferThreshold ?? 30}%)`);
+  }
+
+  const runOptions = { remoteAccess };
+  if (preferName) runOptions.preferredAccount = preferName;
+  if (preferThreshold != null) runOptions.preferThreshold = preferThreshold;
+  await run(claudeArgs, selectedAccount, accounts, runOptions);
 }
 
 // ─── Use & Priority Commands ────────────────────────────────────────────────
@@ -1580,6 +1614,44 @@ function extractAccountFlag(args) {
   return null;
 }
 
+/**
+ * Extract --prefer and --prefer-threshold flags from args (consumed, not passed to claude).
+ *
+ * @param {string[]} args - Mutated in place to remove consumed flags
+ * @returns {{ preferredAccount: string|null, preferThreshold: number|null }}
+ */
+function extractPreferFlags(args) {
+  let preferredAccount = null;
+  let preferThreshold = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--prefer') {
+      if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+        console.error('Error: --prefer requires an account name.');
+        process.exit(1);
+      }
+      preferredAccount = args[i + 1];
+      args.splice(i, 2);
+      i--;
+    } else if (args[i] === '--prefer-threshold') {
+      if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+        console.error('Error: --prefer-threshold requires a number (1-99).');
+        process.exit(1);
+      }
+      const val = parseInt(args[i + 1], 10);
+      if (isNaN(val) || val < 1 || val > 99) {
+        console.error('Error: --prefer-threshold must be a number between 1 and 99.');
+        process.exit(1);
+      }
+      preferThreshold = val;
+      args.splice(i, 2);
+      i--;
+    }
+  }
+
+  return { preferredAccount, preferThreshold };
+}
+
 function printHelp() {
   console.log(`
 claude-nonstop — Multi-account switching + Slack remote access for Claude Code
@@ -1613,8 +1685,10 @@ Commands:
   uninstall            Remove claude-nonstop completely
 
 Options:
-  -a, --account <name>    Use a specific account
-  --remote-access         Run in tmux with Slack channels
+  -a, --account <name>          Use a specific account
+  --remote-access               Run in tmux with Slack channels
+  --prefer <name>               Return to this account when its session usage recovers
+  --prefer-threshold <1-99>     Session % threshold for return (default: 30)
 
 All other arguments are passed through to \`claude\`.
 Run \`setup --help\`, \`webhook\`, or \`hooks\` for subcommand details.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
 import path from 'node:path';
 import { readCredentials } from './keychain.js';
-import { checkAllUsage } from './usage.js';
+import { checkAllUsage, checkUsage } from './usage.js';
 import { pickBestAccount, effectiveUtilization } from './scorer.js';
 import { findLatestSession, migrateSession } from './session.js';
 import { reauthExpiredAccounts } from './reauth.js';
@@ -51,6 +51,10 @@ const KILL_ESCALATION_DELAY = 3000;
 const EXHAUSTION_THRESHOLD = 99;
 /** Maximum sleep duration when waiting for a rate limit reset (6 hours). */
 const MAX_SLEEP_MS = 6 * 60 * 60 * 1000;
+/** Default polling interval for preferred account recovery check (ms). */
+const PREFER_POLL_INTERVAL_MS = 120_000;
+/** Default session utilization threshold (%) for preferred account return. */
+const PREFER_THRESHOLD_DEFAULT = 30;
 
 // ─── ANSI Stripping ────────────────────────────────────────────────────────
 
@@ -180,12 +184,48 @@ function deactivateStaleChannels(tmuxSessionName, channelMapPath) {
 }
 
 /**
+ * Start polling a preferred account's usage to detect recovery.
+ * Returns an AbortController whose signal fires when usage drops below threshold,
+ * and a cleanup function to stop the timer.
+ *
+ * @param {{ name: string, configDir: string }} preferredAccount
+ * @param {number} threshold - Session utilization % below which to trigger return
+ * @param {number} intervalMs - Polling interval in milliseconds
+ * @returns {{ controller: AbortController, cleanup: () => void }}
+ */
+function startPreferredAccountPoller(preferredAccount, threshold, intervalMs) {
+  const controller = new AbortController();
+
+  const timer = setInterval(async () => {
+    try {
+      const creds = readCredentials(preferredAccount.configDir);
+      if (!creds.token) return;
+
+      const usage = await checkUsage(creds.token);
+      if (usage.error) return;
+
+      const sessionUtil = usage.sessionPercent || 0;
+      if (sessionUtil <= threshold) {
+        console.error(`\n[claude-nonstop] Preferred account "${preferredAccount.name}" recovered (session: ${sessionUtil}%). Switching back...`);
+        clearInterval(timer);
+        controller.abort();
+      }
+    } catch {
+      // Non-fatal — skip this poll cycle
+    }
+  }, intervalMs);
+
+  const cleanup = () => clearInterval(timer);
+  return { controller, cleanup };
+}
+
+/**
  * Run Claude Code with automatic account switching.
  *
  * @param {string[]} claudeArgs - Arguments to pass to `claude`
  * @param {{ name: string, configDir: string }} selectedAccount - Account to use
  * @param {Array<{ name: string, configDir: string }>} allAccounts - All registered accounts
- * @param {{ maxSwaps?: number, remoteAccess?: boolean }} options - Runner options
+ * @param {{ maxSwaps?: number, remoteAccess?: boolean, preferredAccount?: string, preferThreshold?: number }} options - Runner options
  */
 export async function run(claudeArgs, selectedAccount, allAccounts, options = {}) {
   // Scale swap budget with account count — with N accounts, you may need
@@ -193,9 +233,19 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
   // The * 2 multiplier allows for accounts recovering mid-session (5-hour resets).
   const maxSwaps = options.maxSwaps ?? Math.max(MAX_SWAPS_DEFAULT, allAccounts.length * 2);
   const remoteAccess = options.remoteAccess ?? false;
+  const preferredAccountName = options.preferredAccount ?? null;
+  const preferThreshold = options.preferThreshold ?? PREFER_THRESHOLD_DEFAULT;
   let currentAccount = selectedAccount;
   let swapCount = 0;
   let sessionId = extractResumeSessionId(claudeArgs);
+
+  // Resolve the preferred account object (if specified)
+  const preferredAccount = preferredAccountName
+    ? allAccounts.find(a => a.name === preferredAccountName) ?? null
+    : null;
+
+  // Track the active poller so we can clean it up
+  let preferPoller = null;
 
   // Deactivate stale channel entries from previous invocations so that
   // reuseChannelForTmuxSession only matches entries from this run
@@ -205,7 +255,74 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
   }
 
   while (swapCount <= maxSwaps) {
-    const result = await runOnce(claudeArgs, currentAccount, sessionId, { remoteAccess });
+    // Start preferred account poller if we're on a non-preferred account
+    let abortSignal = null;
+    if (preferredAccount && currentAccount.name !== preferredAccount.name) {
+      if (preferPoller) preferPoller.cleanup();
+      preferPoller = startPreferredAccountPoller(preferredAccount, preferThreshold, PREFER_POLL_INTERVAL_MS);
+      abortSignal = preferPoller.controller.signal;
+    } else {
+      // On the preferred account — no need to poll
+      if (preferPoller) {
+        preferPoller.cleanup();
+        preferPoller = null;
+      }
+    }
+
+    const result = await runOnce(claudeArgs, currentAccount, sessionId, { remoteAccess, abortSignal });
+
+    // Clean up poller after runOnce returns (will be recreated if needed)
+    if (preferPoller) {
+      preferPoller.cleanup();
+      preferPoller = null;
+    }
+
+    // Preferred account recovered — switch back without counting as a swap
+    if (result.preferredReturn) {
+      const cwd = process.cwd();
+      const session = result.sessionId
+        ? { sessionId: result.sessionId }
+        : findLatestSession(currentAccount.configDir, cwd);
+
+      if (session) {
+        const migration = migrateSession(
+          currentAccount.configDir,
+          preferredAccount.configDir,
+          cwd,
+          session.sessionId
+        );
+        if (migration.success) {
+          sessionId = session.sessionId;
+          console.error(`[claude-nonstop] Session ${sessionId} migrated to "${preferredAccount.name}"`);
+        } else {
+          console.error(`[claude-nonstop] Migration to preferred account failed: ${migration.error}`);
+          console.error('[claude-nonstop] Continuing on current account');
+          // Stay on current account — fall through to a normal runOnce retry
+          continue;
+        }
+      } else {
+        sessionId = null;
+      }
+
+      if (sessionId) {
+        claudeArgs = buildResumeArgs(claudeArgs, sessionId, RATE_LIMIT_CONTINUE_MSG);
+      }
+
+      if (remoteAccess) {
+        spawnHookNotify('account-switch', {
+          session_id: sessionId || null,
+          cwd: process.cwd(),
+          from_account: currentAccount.name,
+          to_account: preferredAccount.name,
+          reason: `preferred account recovered (session ≤${preferThreshold}%)`,
+          swap_count: swapCount,
+          max_swaps: maxSwaps,
+        });
+      }
+
+      currentAccount = preferredAccount;
+      continue;
+    }
 
     if (result.exitCode !== null && !result.rateLimitDetected) {
       // Normal exit — propagate the exit code
@@ -247,7 +364,26 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
 
     let accountsWithUsage = await checkAllUsage(accountsWithTokens);
     const hasPriorities = accountsWithUsage.some(a => a.priority != null);
-    let best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: hasPriorities });
+
+    // If preferred account is set and not the one that just rate-limited,
+    // check if it has recovered before falling through to pickBestAccount
+    let best = null;
+    if (preferredAccount && currentAccount.name !== preferredAccount.name) {
+      const prefUsage = accountsWithUsage.find(a => a.name === preferredAccount.name);
+      if (prefUsage && !prefUsage.usage?.error) {
+        const sessionUtil = prefUsage.usage.sessionPercent || 0;
+        if (sessionUtil <= preferThreshold) {
+          best = {
+            account: prefUsage,
+            reason: `preferred account recovered (session: ${sessionUtil}%)`,
+          };
+        }
+      }
+    }
+
+    if (!best) {
+      best = pickBestAccount(accountsWithUsage, currentAccount.name, { usePriority: hasPriorities });
+    }
 
     // If best candidate is near-exhausted, sleep until earliest reset instead of thrashing.
     // Include all accounts (even current) when finding reset times — after sleeping,
@@ -384,7 +520,11 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
 /**
  * Run Claude once, monitoring for rate limits.
  *
- * @returns {Promise<{ exitCode: number|null, rateLimitDetected: boolean, resetTime: string|null, sessionId: string|null }>}
+ * @param {string[]} claudeArgs
+ * @param {{ name: string, configDir: string }} account
+ * @param {string|null} existingSessionId
+ * @param {{ remoteAccess?: boolean, abortSignal?: AbortSignal }} options
+ * @returns {Promise<{ exitCode: number|null, rateLimitDetected: boolean, preferredReturn: boolean, resetTime: string|null, sessionId: string|null }>}
  */
 function runOnce(claudeArgs, account, existingSessionId, options = {}) {
   return new Promise((resolve) => {
@@ -423,8 +563,34 @@ function runOnce(claudeArgs, account, existingSessionId, options = {}) {
     process.stdin.on('error', () => {});
 
     let rateLimitDetected = false;
+    let preferredReturn = false;
     let resetTime = null;
     let outputBuffer = '';
+
+    // Listen for preferred account recovery signal (abort from poller)
+    if (options.abortSignal) {
+      const onAbort = () => {
+        if (rateLimitDetected) return; // rate limit kill already in progress
+        preferredReturn = true;
+        child.kill('SIGTERM');
+        setTimeout(() => {
+          try { child.kill('SIGKILL'); } catch {}
+        }, KILL_ESCALATION_DELAY);
+      };
+      if (options.abortSignal.aborted) {
+        // Already aborted before runOnce started — trigger immediately
+        preferredReturn = true;
+        // Delay kill to after PTY is set up (next tick)
+        process.nextTick(() => {
+          child.kill('SIGTERM');
+          setTimeout(() => {
+            try { child.kill('SIGKILL'); } catch {}
+          }, KILL_ESCALATION_DELAY);
+        });
+      } else {
+        options.abortSignal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
 
     child.onData((data) => {
       process.stdout.write(data);
@@ -435,7 +601,7 @@ function runOnce(claudeArgs, account, existingSessionId, options = {}) {
         outputBuffer = outputBuffer.slice(-OUTPUT_BUFFER_TRIM);
       }
 
-      if (rateLimitDetected) return;
+      if (rateLimitDetected || preferredReturn) return;
 
       // Primary pattern: "Limit reached · resets ..."
       // Strip ANSI codes before matching — FORCE_COLOR=1 means output has styling
@@ -474,7 +640,7 @@ function runOnce(claudeArgs, account, existingSessionId, options = {}) {
 
     for (const sig of signals) {
       const handler = () => {
-        if (!rateLimitDetected) {
+        if (!rateLimitDetected && !preferredReturn) {
           try { child.kill(sig); } catch {}
         }
       };
@@ -489,6 +655,7 @@ function runOnce(claudeArgs, account, existingSessionId, options = {}) {
       resolve({
         exitCode: exitCode ?? null,
         rateLimitDetected,
+        preferredReturn,
         resetTime,
         sessionId: existingSessionId,
       });
@@ -563,4 +730,5 @@ export {
   RATE_LIMIT_CONTINUE_MSG, FLAGS_WITH_VALUES,
   findEarliestReset, formatDuration, sleep, deactivateStaleChannels,
   EXHAUSTION_THRESHOLD, MAX_SLEEP_MS,
+  startPreferredAccountPoller, PREFER_POLL_INTERVAL_MS, PREFER_THRESHOLD_DEFAULT,
 };


### PR DESCRIPTION
## Summary

- Add `--prefer <name>` CLI option that automatically returns to a designated account when its session usage recovers after a rate-limit switch
- Add `--prefer-threshold <1-99>` option to configure the return threshold (default: 30%)
- Background poller checks preferred account's session usage every 2 minutes via the Anthropic usage API
- Works with both `claude-nonstop` (run) and `claude-nonstop resume` commands

## How it works

1. User runs `claude-nonstop --prefer main`
2. Rate limit on "main" → switches to another account (existing behavior)
3. Poller starts: checks "main" session usage every 120s
4. When session usage ≤ 30% → kills current process, migrates session back, resumes on "main"
5. Preferred return does **not** count against the swap budget

## Multi-session safety

- Poller and AbortController are scoped locally to `run()` — no shared state between concurrent sessions
- Session migration is keyed by session ID, so different sessions don't interfere
- Usage API calls are read-only GETs, safe for concurrent access

## Files changed

- `lib/runner.js` — `startPreferredAccountPoller()`, `run()` prefer-return logic, `runOnce()` AbortSignal support
- `bin/claude-nonstop.js` — `extractPreferFlags()`, flag parsing in `cmdRun`/`cmdResume`, help text

## Test plan

- [ ] Verify `npm run check` passes (syntax validation)
- [ ] Verify `--prefer` with non-existent account name shows error
- [ ] Verify `--prefer-threshold` validates range 1-99
- [ ] Verify without `--prefer`, existing behavior is unchanged (no poller created)
- [ ] Verify `claude-nonstop help` shows new options
- [ ] End-to-end: run with `--prefer`, trigger rate limit, confirm return when usage recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)