### PR TITLE
Identify accounts by organization, not email

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,9 +254,9 @@ If `npm install -g` fails with compilation errors (gyp, node-pty), the user need
 
 **The default account is automatic.** If the user already has Claude Code set up (`~/.claude` exists), it is auto-registered as "default" on first run. Verify with `claude-nonstop list`. Do not try to `add default` — it is handled automatically.
 
-For multi-account switching, the user needs additional accounts (each must be a **different** Claude subscription with a different email). For each additional account:
+For multi-account switching, the user needs additional accounts (each must be a **different** Claude organization). Two accounts can share the same email if they belong to different organizations (e.g., a personal Max plan and an enterprise org). For each additional account:
 
-**Duplicate protection:** If the user logs in with the same email as an existing account, claude-nonstop detects the duplicate after login, removes the new account, and exits with an error. You do not need to check for duplicates yourself.
+**Duplicate protection:** If the user logs in with the same organization as an existing account, claude-nonstop detects the duplicate after login, removes the new account, and exits with an error. Same-email accounts with different organizations are allowed — the user selects the target org during the browser OAuth flow. You do not need to check for duplicates yourself.
 
 **Agents can automate this step.** The `add` command uses `claude auth login` which opens the user's browser for OAuth and waits for completion — no interactive Claude session needed. You can run it directly:
 

--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -153,21 +153,29 @@ async function cmdAdd(args) {
     console.log('');
     console.log(`Account "${name}" authenticated. Checking for duplicates...`);
 
-    // Duplicate detection: compare profile email against existing accounts
+    // Duplicate detection: identity is the ORGANIZATION, not the email.
+    // One email can own multiple orgs — e.g. an enterprise email that, per
+    // company policy, has both an enterprise org and a personal Max plan org —
+    // each a distinct subscription with its own quota. We key on
+    // organization.uuid; only when org info is unavailable do we fall back to
+    // email so older/edge tokens still get some duplicate protection.
     const newProfile = await fetchProfile(creds.token);
-    if (newProfile.email) {
+    const newIdentity = newProfile.orgId || newProfile.email;
+    if (newIdentity) {
       const existingAccounts = getAccounts().filter(a => a.name !== name);
       const existingProfiles = await Promise.all(existingAccounts.map(async (a) => {
         const existingCreds = readCredentials(a.configDir);
-        if (!existingCreds.token) return { ...a, email: null };
+        if (!existingCreds.token) return { ...a, identity: null, profile: null };
         const profile = await fetchProfile(existingCreds.token);
-        return { ...a, email: profile.email };
+        return { ...a, identity: profile.orgId || profile.email, profile };
       }));
 
-      const duplicate = existingProfiles.find(a => a.email && a.email === newProfile.email);
+      const duplicate = existingProfiles.find(a => a.identity && a.identity === newIdentity);
       if (duplicate) {
-        console.error(`\nError: "${name}" (${newProfile.email}) is the same account as "${duplicate.name}".`);
-        console.error('Each account must be a different Claude subscription.');
+        const label = formatOrgLabel(newProfile);
+        console.error(`\nError: "${name}" (${label}) is the same organization as "${duplicate.name}".`);
+        console.error('Each account must be a different Claude organization (org).');
+        console.error('Tip: if you meant a different org under the same email, pick that org in the browser sign-in.');
         console.error(`Removing "${name}"...`);
         removeAccount(name);
         process.exit(1);
@@ -175,7 +183,8 @@ async function cmdAdd(args) {
     }
 
     console.log(`Account "${name}" added successfully.`);
-    if (newProfile.email) console.log(`Email: ${newProfile.email}`);
+    const addedLabel = formatOrgLabel(newProfile);
+    if (addedLabel) console.log(`Identity: ${addedLabel}`);
   } catch (err) {
     console.error(`Error: ${err.message}`);
     process.exit(1);
@@ -1621,11 +1630,24 @@ Run \`setup --help\`, \`webhook\`, or \`hooks\` for subcommand details.
 `.trim());
 }
 
-function formatUserInfo({ name, email }) {
-  if (name && email) return ` (${name} — ${email})`;
-  if (name) return ` (${name})`;
-  if (email) return ` (${email})`;
-  return '';
+function formatUserInfo({ name, email, orgName, orgType } = {}) {
+  const who = name && email ? `${name} — ${email}` : (name || email || '');
+  const org = formatOrgSuffix({ orgName, orgType });
+  const inner = [who, org].filter(Boolean).join(' · ');
+  return inner ? ` (${inner})` : '';
+}
+
+/** Human-readable org suffix, e.g. "Speak [enterprise]". */
+function formatOrgSuffix({ orgName, orgType } = {}) {
+  if (!orgName) return '';
+  const t = orgType ? orgType.replace(/^claude_/, '') : '';
+  return t ? `${orgName} [${t}]` : orgName;
+}
+
+/** Full identity label for add/dedup messages, e.g. "sj@x.com · Speak [enterprise]". */
+function formatOrgLabel({ email, orgName, orgType } = {}) {
+  const org = formatOrgSuffix({ orgName, orgType });
+  return [email, org].filter(Boolean).join(' · ');
 }
 
 function makeBar(percent, width = 20) {

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -108,15 +108,24 @@ export async function fetchProfile(token) {
 
     clearTimeout(timeoutId);
 
-    if (!res.ok) return { name: null, email: null };
+    if (!res.ok) return { name: null, email: null, orgId: null, orgName: null, orgType: null, accountUuid: null };
 
     const data = await res.json();
     return {
       name: data.account?.full_name || data.account?.display_name || null,
       email: data.account?.email || null,
+      // Organization-level identity. One email can belong to multiple orgs —
+      // e.g. an enterprise email that, per company policy, has both an
+      // enterprise org and a personal Max plan org — each with its own quota
+      // and OAuth token. organization.uuid is globally unique, so it — not
+      // email — is the correct identity key for account switching.
+      orgId: data.organization?.uuid || null,
+      orgName: data.organization?.name || null,
+      orgType: data.organization?.organization_type || null,
+      accountUuid: data.account?.uuid || null,
     };
   } catch {
-    return { name: null, email: null };
+    return { name: null, email: null, orgId: null, orgName: null, orgType: null, accountUuid: null };
   }
 }
 

--- a/test/unit/lib/usage.test.js
+++ b/test/unit/lib/usage.test.js
@@ -177,6 +177,73 @@ describe('fetchProfile', () => {
     const result = await fetchProfile('sk-ant-oat01-test');
     assert.equal(result.name, 'Display Name');
   });
+
+  it('extracts organization identity (uuid, name, type) and account uuid', async () => {
+    // Real shape returned by api.anthropic.com/api/oauth/profile for an
+    // enterprise email account that has both an enterprise org and a personal
+    // Max plan org under the same email, per company policy.
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        account: { uuid: 'acct-123', full_name: 'Alice Example', email: 'alice@example.com', has_claude_max: true },
+        organization: { uuid: 'org-ent-uuid', name: 'Acme Corp', organization_type: 'claude_enterprise' },
+      }),
+    });
+
+    const r = await fetchProfile('sk-ant-oat01-test');
+    assert.equal(r.email, 'alice@example.com');
+    assert.equal(r.orgId, 'org-ent-uuid');
+    assert.equal(r.orgName, 'Acme Corp');
+    assert.equal(r.orgType, 'claude_enterprise');
+    assert.equal(r.accountUuid, 'acct-123');
+  });
+
+  it('distinguishes two orgs under the SAME email by orgId', async () => {
+    const byOrg = {
+      'sk-ant-oat01-max': {
+        account: { uuid: 'acct-1', email: 'alice@example.com' },
+        organization: { uuid: 'org-max', name: 'Personal', organization_type: 'claude_max' },
+      },
+      'sk-ant-oat01-ent': {
+        account: { uuid: 'acct-1', email: 'alice@example.com' },
+        organization: { uuid: 'org-ent', name: 'Acme Corp', organization_type: 'claude_enterprise' },
+      },
+    };
+    globalThis.fetch = async (_url, opts) => {
+      const token = opts.headers.Authorization.replace('Bearer ', '');
+      return { ok: true, json: async () => byOrg[token] };
+    };
+
+    const max = await fetchProfile('sk-ant-oat01-max');
+    const ent = await fetchProfile('sk-ant-oat01-ent');
+    // Same email, same account uuid — but DIFFERENT org identity.
+    assert.equal(max.email, ent.email);
+    assert.equal(max.accountUuid, ent.accountUuid);
+    assert.notEqual(max.orgId, ent.orgId);
+  });
+
+  it('returns null org fields when organization is absent (email-only fallback)', async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ account: { email: 'solo@example.com', full_name: 'Solo' } }),
+    });
+    const r = await fetchProfile('sk-ant-oat01-test');
+    assert.equal(r.orgId, null);
+    assert.equal(r.orgName, null);
+    assert.equal(r.email, 'solo@example.com');
+  });
+
+  it('returns null org fields on HTTP error and on network error', async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 500 });
+    let r = await fetchProfile('sk-ant-oat01-test');
+    assert.equal(r.orgId, null);
+    assert.equal(r.orgName, null);
+
+    globalThis.fetch = async () => { throw new Error('net'); };
+    r = await fetchProfile('sk-ant-oat01-test');
+    assert.equal(r.orgId, null);
+    assert.equal(r.accountUuid, null);
+  });
 });
 
 describe('checkAllUsage', () => {
@@ -197,7 +264,7 @@ describe('checkAllUsage', () => {
       'sk-ant-oat01-b': { five_hour: { utilization: 0.60 }, seven_day: { utilization: 0.40 } },
     };
 
-    globalThis.fetch = async (url, opts) => {
+    globalThis.fetch = async (_url, opts) => {
       const token = opts.headers.Authorization.replace('Bearer ', '');
       return {
         ok: true,


### PR DESCRIPTION
## Problem

`add`'s duplicate detection compares the profile **email**. That rejects two
distinct Claude **organizations that share one email** — for example a personal
Max org and an enterprise org under the same account. Each org is a separate
subscription with its own quota and OAuth token, so they're legitimately
separate switchable accounts, but `add` removes the second one as a "duplicate":

```
Error: "enterprise" (alice@example.com) is the same account as "default".
Each account must be a different Claude subscription.
```

## Fix

Identify accounts by `organization.uuid` (already returned by
`/api/oauth/profile`) instead of email. It's globally unique, so it correctly
distinguishes both the same-email-different-org case and the ordinary
different-email case. Email remains a fallback only when org info is absent, so
older/edge tokens keep their existing duplicate protection.

### Changes
- `lib/usage.js` — `fetchProfile` now also returns `orgId`, `orgName`,
  `orgType`, `accountUuid`.
- `bin/claude-nonstop.js` — dedup keys on `orgId`; `add`/`list`/`status` show
  `email · Org [type]` (e.g. `alice@example.com · Acme Corp [enterprise]`) so
  same-email orgs are distinguishable at a glance.
- Tests — org extraction, same-email/different-org disambiguation, and
  null-org/error fallbacks.

### Tests
All existing tests pass plus 4 new cases (418 total):

```
# tests 418
# pass 418
# fail 0
```

No mocks of the code under test — the new cases drive `fetchProfile` with the
real profile-API JSON shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)