### PR TITLE
fix(failover): address PR #24 review findings (AGE-69/71/72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,76 @@ This creates a tmux session named after the current directory, enables `--danger
 - Webhook not receiving? Run `claude-nonstop webhook status` then `webhook logs`
 - Messages not reaching Claude? Check `tmux ls` and that Claude is waiting for input
 
+## Custom Endpoint Failover
+
+Custom Anthropic-API-compatible endpoints (proxies, Bedrock adapters, etc.) can be added as **peers** in the account pool. When all OAuth accounts exceed their usage threshold, the failover monitor switches to the first healthy custom peer.
+
+### Configuration (`~/.claude-nonstop/failover.json`)
+
+```jsonc
+{
+  "peers": [
+    {
+      "name": "manifest-proxy",           // Unique name for logging/state
+      "kind": "custom_endpoint",          // Required
+      "baseUrl": "https://proxy.example.com",
+      "authToken": "sk-ant-...",          // Literal token (for quick testing)
+      // OR: "authTokenEnv": "MY_TOKEN",  // Read from environment variable
+      // OR: "authTokenFile": "/run/secrets/token",  // Read from file (Docker/systemd-creds)
+      "model": "auto",                   // Optional (default: "auto")
+      "thresholds": {                     // Optional per-account overrides
+        "switch_at": 70,                  // Switch TO this peer when best OAuth ≥ 70%
+        "switch_back_at": 40              // Switch BACK to OAuth when best OAuth ≤ 40%
+      }
+    },
+    {
+      "name": "bedrock",
+      "kind": "custom_endpoint",
+      "baseUrl": "https://bedrock-proxy.example.com",
+      "authTokenEnv": "BEDROCK_AUTH_TOKEN",
+      "model": "claude-sonnet-4-5-20250514",
+      "thresholds": { "switch_at": 90, "switch_back_at": 60 }
+    }
+  ],
+  "thresholds": {                         // Global defaults
+    "switch_at": 80,
+    "switch_back_at": 50,
+    "recheck_interval_seconds": 60
+  }
+}
+```
+
+See [`failover.example.json`](failover.example.json) for a complete example including the legacy single `fallback` entry.
+
+### Per-Account Thresholds
+
+Both OAuth accounts and custom peers can have independent thresholds:
+
+```bash
+# Set thresholds for an OAuth account
+claude-nonstop set-threshold main 60 30   # switch_at=60, switch_back_at=30
+```
+
+Peers define thresholds directly in `failover.json` (see above). When a peer has `switch_at: 70`, the monitor switches to it as soon as the best OAuth account hits 70% — even if the global threshold is 80%.
+
+### Non-TTY Auto-Promote
+
+In non-interactive contexts (piped stdin, e.g. paperclip runs), the runner automatically promotes to the first healthy custom peer to avoid OAuth login prompts. No wrapper script needed — this is built into the runner.
+
+### Failover Monitor
+
+The background monitor polls OAuth usage and custom endpoint health:
+
+```bash
+claude-nonstop failover start     # Start background monitor (writes ~/.claude-nonstop/state/active.json)
+claude-nonstop failover stop      # Stop monitor
+claude-nonstop failover status    # Show current state
+claude-nonstop failover check     # One-shot check (writes state)
+claude-nonstop failover dry-run   # Preview decision without writing state
+```
+
+Use `claude-failover.service` (systemd) for automatic restart on Linux.
+
 ## How It Works
 
 **Multi-account switching** queries the Anthropic usage API for all accounts (~200ms), picks the one with the most headroom, then monitors Claude's output for rate limit messages in real-time. On detection: kill, migrate session files to the next account, resume with `claude --resume`.
@@ -268,6 +338,13 @@ claude-nonstop/
 │   ├── tmux.js                   tmux session management
 │   ├── reauth.js                 Re-authentication flow
 │   └── platform.js               OS detection
+│   └── failover/                 Custom endpoint failover layer
+│       ├── provider.js           OAuthProvider + CustomEndpointProvider
+│       ├── pool.js               Unified OAuth + custom endpoint pool
+│       ├── monitor.js            Failover state machine + background poller
+│       ├── active.js             Runtime provider resolution + non-TTY auto-promote
+│       ├── cli.js                `failover` subcommand (start/stop/check/dry-run)
+│       └── cli_helpers.js        Shared helpers (token resolution)
 ├── remote/                       Slack remote access subsystem (CJS)
 │   ├── hook-notify.cjs           Hook entry point
 │   ├── channel-manager.cjs       Slack channel lifecycle

--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -774,7 +774,7 @@ async function cmdUse(useArgs) {
       const label = match ? match.name : 'unknown';
       console.error(`Current: ${label} (${current})`);
     } else {
-      console.error(`Current: default (${DEFAULT_CLAUDE_DIR})`);
+      console.error(`Current: default (${DEFAULT_CLAUDE_DIR()})`);
     }
     return;
   }
@@ -783,7 +783,7 @@ async function cmdUse(useArgs) {
   if (flag === '--unset') {
     // stdout: eval-friendly command; stderr: human message
     console.log('unset CLAUDE_CONFIG_DIR');
-    console.error(`Reverted to default account (${DEFAULT_CLAUDE_DIR})`);
+    console.error(`Reverted to default account (${DEFAULT_CLAUDE_DIR()})`);
     return;
   }
 
@@ -1031,7 +1031,7 @@ SLACK_CHANNEL_PREFIX=${channelPrefix}
 DEFAULT_TMUX_SESSION=${defaultTmux}
 `;
 
-  const envDir = CONFIG_DIR;
+  const envDir = CONFIG_DIR();
   if (!existsSync(envDir)) mkdirSync(envDir, { recursive: true });
   const envPath = join(envDir, '.env');
   // Atomic write with restrictive permissions (contains Slack tokens)
@@ -1424,7 +1424,7 @@ async function cmdUninstall(uninstallArgs = []) {
 
   // 3. Remove keychain credentials for non-default accounts
   const accounts = getAccounts();
-  const keychainAccounts = accounts.filter(a => a.configDir !== DEFAULT_CLAUDE_DIR);
+  const keychainAccounts = accounts.filter(a => a.configDir !== DEFAULT_CLAUDE_DIR());
   if (keychainAccounts.length > 0) {
     console.log('Removing keychain credentials...');
     for (const account of keychainAccounts) {
@@ -1440,9 +1440,9 @@ async function cmdUninstall(uninstallArgs = []) {
   }
 
   // 4. Remove ~/.claude-nonstop/ directory
-  if (existsSync(CONFIG_DIR)) {
-    console.log(`Removing ${CONFIG_DIR}...`);
-    rmSync(CONFIG_DIR, { recursive: true, force: true });
+  if (existsSync(CONFIG_DIR())) {
+    console.log(`Removing ${CONFIG_DIR()}...`);
+    rmSync(CONFIG_DIR(), { recursive: true, force: true });
     console.log('  Config directory removed.');
   }
 
@@ -1472,7 +1472,7 @@ function removeHooksFromAllProfiles() {
   const settingsPaths = accounts.map(a => join(a.configDir, 'settings.json'));
 
   // Also check default ~/.claude/settings.json if not already in accounts
-  const defaultSettings = join(DEFAULT_CLAUDE_DIR, 'settings.json');
+  const defaultSettings = join(DEFAULT_CLAUDE_DIR(), 'settings.json');
   if (!settingsPaths.includes(defaultSettings)) {
     settingsPaths.push(defaultSettings);
   }

--- a/failover.example.json
+++ b/failover.example.json
@@ -1,0 +1,53 @@
+{
+  "_comment": "Example failover.json showing custom endpoint peers with per-account thresholds.",
+  "primary": {
+    "kind": "oauth",
+    "account": "rahima"
+  },
+  "fallback": {
+    "_comment": "Legacy single-fallback entry (auto-promoted to a peer named '_fallback'). Keep for backward compat or use 'peers' array instead.",
+    "kind": "custom_endpoint",
+    "baseUrl": "http://localhost:2099",
+    "authTokenEnv": "ANTHROPIC_AUTH_TOKEN",
+    "model": "auto"
+  },
+  "peers": [
+    {
+      "name": "manifest-proxy",
+      "kind": "custom_endpoint",
+      "baseUrl": "https://my-anthropic-proxy.example.com",
+      "authToken": "sk-ant-...",
+      "model": "auto",
+      "thresholds": {
+        "switch_at": 70,
+        "switch_back_at": 40
+      }
+    },
+    {
+      "name": "bedrock",
+      "kind": "custom_endpoint",
+      "baseUrl": "https://bedrock-proxy.example.com",
+      "authTokenEnv": "BEDROCK_AUTH_TOKEN",
+      "model": "claude-sonnet-4-5-20250514",
+      "thresholds": {
+        "switch_at": 90,
+        "switch_back_at": 60
+      }
+    },
+    {
+      "name": "docker-secret",
+      "kind": "custom_endpoint",
+      "baseUrl": "https://internal-proxy.example.com",
+      "authTokenFile": "/run/secrets/anthropic_token",
+      "model": "auto"
+    }
+  ],
+  "thresholds": {
+    "switch_at": 80,
+    "switch_back_at": 50,
+    "recheck_interval_seconds": 60
+  },
+  "logging": {
+    "path": "/root/.claude-nonstop/logs/failover.log"
+  }
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,17 +2,27 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from '
 import { homedir } from 'os';
 import { join, normalize } from 'path';
 
-const CONFIG_DIR = join(homedir(), '.claude-nonstop');
-const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
-const PROFILES_DIR = join(CONFIG_DIR, 'profiles');
-const DEFAULT_CLAUDE_DIR = normalize(join(homedir(), '.claude'));
+/**
+ * Resolve the effective home directory for config storage.
+ *
+ * Honors $HOME for test isolation and per-user process overrides; falls
+ * back to os.homedir() for production.
+ */
+function effectiveHomedir() {
+  return process.env.HOME || homedir();
+}
+
+const CONFIG_DIR = () => join(effectiveHomedir(), '.claude-nonstop');
+const CONFIG_FILE = () => CONFIG_DIR() + '/config.json';
+const PROFILES_DIR = () => CONFIG_DIR() + '/profiles';
+const DEFAULT_CLAUDE_DIR = () => normalize(join(effectiveHomedir(), '.claude'));
 
 /**
  * Ensure the config directory and profiles directory exist.
  */
 export function ensureConfigDir() {
-  if (!existsSync(CONFIG_DIR)) mkdirSync(CONFIG_DIR, { recursive: true });
-  if (!existsSync(PROFILES_DIR)) mkdirSync(PROFILES_DIR, { recursive: true });
+  if (!existsSync(CONFIG_DIR())) mkdirSync(CONFIG_DIR(), { recursive: true });
+  if (!existsSync(PROFILES_DIR())) mkdirSync(PROFILES_DIR(), { recursive: true });
 }
 
 /**
@@ -24,9 +34,9 @@ export function loadConfig() {
 
   let config = { accounts: [] };
 
-  if (existsSync(CONFIG_FILE)) {
+  if (existsSync(CONFIG_FILE())) {
     try {
-      config = JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'));
+      config = JSON.parse(readFileSync(CONFIG_FILE(), 'utf-8'));
     } catch {
       config = { accounts: [] };
     }
@@ -41,9 +51,10 @@ export function loadConfig() {
  */
 export function ensureDefaultAccount() {
   const config = loadConfig();
-  const hasDefault = config.accounts.some(a => a.configDir === DEFAULT_CLAUDE_DIR);
-  if (!hasDefault && existsSync(DEFAULT_CLAUDE_DIR)) {
-    config.accounts.unshift({ name: 'default', configDir: DEFAULT_CLAUDE_DIR });
+  const defaultDir = DEFAULT_CLAUDE_DIR();
+  const hasDefault = config.accounts.some(a => a.configDir === defaultDir);
+  if (!hasDefault && existsSync(defaultDir)) {
+    config.accounts.unshift({ name: 'default', configDir: defaultDir });
     saveConfig(config);
   }
 }
@@ -53,9 +64,9 @@ export function ensureDefaultAccount() {
  */
 export function saveConfig(config) {
   ensureConfigDir();
-  const tmpFile = `${CONFIG_FILE}.${process.pid}.${Date.now()}.tmp`;
+  const tmpFile = `${CONFIG_FILE()}.${process.pid}.${Date.now()}.tmp`;
   writeFileSync(tmpFile, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
-  renameSync(tmpFile, CONFIG_FILE);
+  renameSync(tmpFile, CONFIG_FILE());
 }
 
 const VALID_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
@@ -91,7 +102,7 @@ export function addAccount(name) {
     throw new Error(`Account "${name}" already exists`);
   }
 
-  const configDir = join(PROFILES_DIR, name);
+  const configDir = join(PROFILES_DIR(), name);
   if (!existsSync(configDir)) mkdirSync(configDir, { recursive: true });
 
   config.accounts.push({ name, configDir });
@@ -108,7 +119,7 @@ export function removeAccount(name) {
   const idx = config.accounts.findIndex(a => a.name === name);
 
   if (idx === -1) throw new Error(`Account "${name}" not found`);
-  if (config.accounts[idx].configDir === DEFAULT_CLAUDE_DIR) {
+  if (config.accounts[idx].configDir === DEFAULT_CLAUDE_DIR()) {
     throw new Error('Cannot remove the default account');
   }
 
@@ -160,4 +171,57 @@ export function getAccounts() {
   return loadConfig().accounts;
 }
 
+/**
+ * Set per-account failover thresholds (switch_at, switch_back_at).
+ *
+ * @param {string} name - Account name
+ * @param {object} thresholds - { switch_at?: number, switch_back_at?: number }
+ */
+export function setAccountThresholds(name, thresholds) {
+  validateAccountName(name);
+  validateThresholds(thresholds);
+
+  const config = loadConfig();
+  const account = config.accounts.find(a => a.name === name);
+  if (!account) throw new Error(`Account "${name}" not found`);
+
+  // Merge into existing thresholds so callers can update one key at a time.
+  account.thresholds = { ...(account.thresholds ?? {}), ...thresholds };
+  saveConfig(config);
+}
+
+/**
+ * Remove per-account failover thresholds (revert to global).
+ *
+ * @param {string} name - Account name
+ */
+export function clearAccountThresholds(name) {
+  validateAccountName(name);
+  const config = loadConfig();
+  const account = config.accounts.find(a => a.name === name);
+  if (!account) throw new Error(`Account "${name}" not found`);
+  delete account.thresholds;
+  saveConfig(config);
+}
+
+/**
+ * Validate a thresholds object: each key, if present, must be an integer
+ * in [0, 100]. switch_back_at should be <= switch_at but we don't enforce
+ * it because the monitor's hysteresis logic can tolerate inversions by
+ * collapsing to whichever is more restrictive.
+ */
+function validateThresholds(thresholds) {
+  if (!thresholds || typeof thresholds !== 'object') {
+    throw new Error('Thresholds must be an object');
+  }
+  for (const key of ['switch_at', 'switch_back_at']) {
+    if (thresholds[key] == null) continue;
+    const n = thresholds[key];
+    if (!Number.isInteger(n) || n < 0 || n > 100) {
+      throw new Error(`${key} must be an integer between 0 and 100`);
+    }
+  }
+}
+
+/** @deprecated Use the function form CONFIG_DIR() instead. */
 export { CONFIG_DIR, PROFILES_DIR, DEFAULT_CLAUDE_DIR };

--- a/lib/failover/active.js
+++ b/lib/failover/active.js
@@ -1,0 +1,114 @@
+/**
+ * Read the active failover state from disk.
+ *
+ * Used by the runner to apply environment variables (ANTHROPIC_BASE_URL,
+ * ANTHROPIC_AUTH_TOKEN) before spawning `claude` when the failover monitor
+ * has decided to switch to a custom endpoint.
+ *
+ * When stdin is not a TTY (e.g. paperclip piped runs), this function
+ * additionally honors the non-TTY auto-promote rule: if the current
+ * provider is "primary" and there is any healthy custom endpoint peer in
+ * the configured failover.json, return that peer instead so we never
+ * trigger OAuth login prompts in non-interactive contexts.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.isInteractive] - Override TTY detection. When
+ *   undefined, falls back to `process.stdin.isTTY`.
+ * @returns {{
+ *   provider: string,
+ *   account: string|null,
+ *   connection: { baseUrl: string, token: string, model: string }|null,
+ *   reason: string,
+ *   autoPromoted: boolean,
+ * }|null} Returns null when no state file exists AND auto-promote is
+ *   not applicable (interactive primary).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadFailoverConfig } from './monitor.js';
+import { buildCustomPeers, getBestProviderOrNull } from './pool.js';
+
+const STATE_FILE = join(homedir(), '.claude-nonstop', 'state', 'active.json');
+const CONFIG_PATH = join(homedir(), '.claude-nonstop', 'failover.json');
+
+/**
+ * Resolve the runtime provider state for the next `claude` invocation.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.isInteractive]
+ * @returns {Promise<{
+ *   provider: string,
+ *   account: string|null,
+ *   connection: { baseUrl: string, token: string, model: string }|null,
+ *   reason: string,
+ *   autoPromoted: boolean,
+ * }>}
+ */
+export async function resolveProvider(opts = {}) {
+  const isInteractive = opts.isInteractive ?? Boolean(process.stdin?.isTTY);
+
+  // Always read the latest state file first.
+  const state = readStateFile();
+  const provider = state?.provider ?? 'primary';
+
+  // Non-TTY auto-promote: when invoked from a piped context, never start
+  // OAuth login. If the monitor hasn't already switched to a custom
+  // endpoint, find the first healthy peer in failover.json and use it.
+  if (!isInteractive && provider === 'primary') {
+    const promoted = await pickFirstHealthyPeer();
+    if (promoted) {
+      return {
+        provider: promoted.name(),
+        account: null,
+        connection: promoted.getConnectionInfo(),
+        reason: 'non_tty_auto_promote',
+        autoPromoted: true,
+      };
+    }
+  }
+
+  if (!state) {
+    // No state yet — return primary. Non-interactive callers without a
+    // peer config will need to fall back to OAuth (which may prompt).
+    return {
+      provider: 'primary',
+      account: null,
+      connection: null,
+      reason: 'no_state_file',
+      autoPromoted: false,
+    };
+  }
+
+  return {
+    provider,
+    account: state.account ?? null,
+    connection: state.connection ?? null,
+    reason: state.reason ?? 'from_state',
+    autoPromoted: false,
+  };
+}
+
+function readStateFile() {
+  if (!existsSync(STATE_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(STATE_FILE, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+async function pickFirstHealthyPeer() {
+  const cfg = existsSync(CONFIG_PATH)
+    ? loadFailoverConfig(CONFIG_PATH)
+    : null;
+  if (!cfg) return null;
+  const peers = buildCustomPeers(cfg);
+  if (peers.length === 0) return null;
+  const { pickBestPeer } = await import('./pool.js');
+  return pickBestPeer(peers, cfg.thresholds);
+}
+
+export { STATE_FILE };

--- a/lib/failover/active.js
+++ b/lib/failover/active.js
@@ -82,13 +82,54 @@ export async function resolveProvider(opts = {}) {
     };
   }
 
+  // Hydrate the state file's token-free connection with the live token from the
+  // configured source (authTokenEnv / authTokenFile / unit file). The state
+  // file deliberately does NOT carry the bearer token (AGE-71) — re-resolve it
+  // here at spawn time so the runner can set ANTHROPIC_AUTH_TOKEN.
+  let connection = null;
+  if (state.connection?.peer) {
+    const live = await hydratePeerConnection(state.connection.peer);
+    if (live) {
+      connection = {
+        baseUrl: state.connection.baseUrl ?? live.baseUrl,
+        token: live.token,
+        model: state.connection.model ?? live.model,
+      };
+    } else {
+      // Peer no longer configured — fall back to a token-free projection so
+      // the runner at least surfaces the right baseUrl/model (token will be
+      // empty and the spawn will fail loudly rather than silently).
+      connection = {
+        baseUrl: state.connection.baseUrl ?? null,
+        token: null,
+        model: state.connection.model ?? null,
+      };
+    }
+  } else if (state.connection?.baseUrl) {
+    // Legacy state file written before AGE-71 — hydrate by config if possible,
+    // otherwise return token-less.
+    connection = { baseUrl: state.connection.baseUrl, token: null, model: state.connection.model ?? null };
+  }
+
   return {
     provider,
     account: state.account ?? null,
-    connection: state.connection ?? null,
+    connection,
     reason: state.reason ?? 'from_state',
     autoPromoted: false,
   };
+}
+
+async function hydratePeerConnection(peerName) {
+  const cfg = existsSync(CONFIG_PATH)
+    ? loadFailoverConfig(CONFIG_PATH)
+    : null;
+  if (!cfg) return null;
+  const peers = buildCustomPeers(cfg);
+  const peer = peers.find((p) => p._name === peerName);
+  if (!peer) return null;
+  const info = peer.getConnectionInfo();
+  return { baseUrl: info.baseUrl, token: info.token, model: info.model };
 }
 
 function readStateFile() {

--- a/lib/failover/cli.js
+++ b/lib/failover/cli.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * claude-nonstop failover subcommand.
+ *
+ *   failover start                Start background monitor (writes state file).
+ *   failover stop                 Stop background monitor (best-effort: pid file).
+ *   failover status               Print current state + last reading.
+ *   failover check                Run one check synchronously, print decision.
+ *   failover dry-run              Print what would happen, change nothing.
+ *
+ * No state file mutation in dry-run mode.
+ *
+ * Backwards compatible with v0.2.0 config (single `fallback` entry, keys
+ * `switch_to_fallback_at` / `switch_back_at`).
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+import { CustomEndpointProvider } from './provider.js';
+import { buildCustomPeers, getBestProviderOrNull } from './pool.js';
+import { readCompatTokenFromUnit } from './cli_helpers.js';
+import {
+  FailoverMonitor,
+  loadFailoverConfig,
+  loadActiveState,
+  STATE_FILE,
+  LOG_FILE,
+} from './monitor.js';
+
+const CONFIG_PATH = join(homedir(), '.claude-nonstop', 'failover.json');
+const PID_FILE = join(homedir(), '.claude-nonstop', 'state', 'failover.pid');
+
+/**
+ * Backwards-compat shim: build providers for callers that still expect the
+ * `{ fallback }` shape from v0.2.0.
+ */
+function buildProviders(cfg) {
+  // pool.js does the full normalization (legacy fallback → peer). This helper
+  // exists only for callers that want a single `fallback` CompatProvider.
+  if (cfg.fallback?.kind !== 'custom_endpoint' && cfg.fallback?.kind !== 'anthropic_compat') {
+    return { fallback: null };
+  }
+  const envVar = cfg.fallback.authTokenEnv ?? 'ANTHROPIC_AUTH_TOKEN';
+  const token = process.env[envVar] || readCompatTokenFromUnit();
+  if (!token) return { fallback: null };
+  const fallback = new CustomEndpointProvider({
+    name: '_fallback',
+    baseUrl: cfg.fallback.baseUrl,
+    token,
+    model: cfg.fallback.model ?? 'auto',
+    thresholds: cfg.fallback.thresholds ?? null,
+  });
+  return { fallback };
+}
+
+function cmdStatus() {
+  const cfg = loadFailoverConfig(CONFIG_PATH);
+  const state = loadActiveState();
+  console.log('failover config:', CONFIG_PATH);
+  console.log('thresholds:', JSON.stringify(cfg.thresholds));
+  const peers = buildCustomPeers(cfg);
+  if (peers.length > 0) {
+    console.log('peers:', peers.map((p) => {
+      const t = p.thresholdOverrides();
+      return `${p.name()}@${p.getConnectionInfo().baseUrl}${t ? ` (${JSON.stringify(t)})` : ''}`;
+    }).join(', '));
+  }
+  if (!state) {
+    console.log('no active state yet (monitor not running or never ticked)');
+    return;
+  }
+  console.log('active state:');
+  console.log(JSON.stringify(state, null, 2));
+  console.log('log:', LOG_FILE);
+}
+
+async function cmdCheck() {
+  const cfg = loadFailoverConfig(CONFIG_PATH);
+  const peers = buildCustomPeers(cfg);
+  if (peers.length === 0) {
+    console.error('failover not configured (need fallback or peers in failover.json)');
+    process.exit(2);
+  }
+  const monitor = new FailoverMonitor({
+    thresholds: cfg.thresholds,
+    cfg,
+    log: (line) => console.log(line),
+  });
+  const state = await monitor.tick();
+  console.log(JSON.stringify(state, null, 2));
+}
+
+async function cmdDryRun() {
+  const cfg = loadFailoverConfig(CONFIG_PATH);
+  const peers = buildCustomPeers(cfg);
+  if (peers.length === 0) {
+    console.error('failover not configured (need fallback or peers in failover.json)');
+    process.exit(2);
+  }
+  const poolResult = await getBestProviderOrNull(cfg.thresholds, cfg);
+  const current = existsSync(STATE_FILE)
+    ? (JSON.parse(readFileSync(STATE_FILE, 'utf-8')).provider ?? 'primary')
+    : 'primary';
+  const { decide } = await import('./monitor.js');
+  const decision = decide(current, poolResult, cfg.thresholds);
+  const out = {
+    mode: 'dry-run',
+    current,
+    pool: poolResult.all,
+    best_oauth: poolResult.best ? {
+      name: poolResult.best.provider.name(),
+      reading: poolResult.best.reading,
+    } : null,
+    best_peer: poolResult.bestPeer ? poolResult.bestPeer.name() : null,
+    would_switch: !!decision,
+    decision,
+    thresholds: cfg.thresholds,
+    peers: peers.map((p) => ({
+      name: p.name(),
+      baseUrl: p.getConnectionInfo().baseUrl,
+      thresholds: p.thresholdOverrides(),
+    })),
+  };
+  console.log(JSON.stringify(out, null, 2));
+}
+
+function cmdStart() {
+  if (existsSync(PID_FILE)) {
+    const pid = parseInt(readFileSync(PID_FILE, 'utf-8').trim(), 10);
+    if (pid && processExists(pid)) {
+      console.log(`failover monitor already running (pid ${pid})`);
+      return;
+    }
+  }
+  mkdirSync(join(homedir(), '.claude-nonstop', 'state'), { recursive: true });
+  const child = spawn(process.execPath, [process.argv[1], '_daemon'], {
+    detached: true,
+    stdio: 'ignore',
+    env: process.env,
+  });
+  child.unref();
+  writeFileSync(PID_FILE, String(child.pid));
+  console.log(`failover monitor started (pid ${child.pid}); log=${LOG_FILE}`);
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function cmdStop() {
+  if (!existsSync(PID_FILE)) {
+    console.log('no pid file; monitor not running');
+    return;
+  }
+  const pid = parseInt(readFileSync(PID_FILE, 'utf-8').trim(), 10);
+  if (pid && processExists(pid)) {
+    try {
+      process.kill(pid, 'SIGTERM');
+      console.log(`stopped failover monitor (pid ${pid})`);
+    } catch (err) {
+      console.log(`failed to stop pid ${pid}: ${err.message}`);
+    }
+  }
+  try { writeFileSync(PID_FILE, ''); } catch {}
+}
+
+async function cmdDaemon() {
+  const cfg = loadFailoverConfig(CONFIG_PATH);
+  const peers = buildCustomPeers(cfg);
+  if (peers.length === 0) {
+    console.error('failover misconfigured (need fallback or peers); exiting');
+    process.exit(2);
+  }
+  const monitor = new FailoverMonitor({ thresholds: cfg.thresholds, cfg });
+  monitor.start();
+  const shutdown = () => monitor.stop();
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+  setInterval(() => {}, 60_000);
+}
+
+async function main() {
+  const sub = process.argv[2];
+  switch (sub) {
+    case 'status': return cmdStatus();
+    case 'check':  return cmdCheck();
+    case 'dry-run': case 'dryrun': return cmdDryRun();
+    case 'start':  return cmdStart();
+    case 'stop':   return cmdStop();
+    case '_daemon': return cmdDaemon();
+    default:
+      console.error('Usage: claude-nonstop failover {status|check|dry-run|start|stop}');
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('failover error:', err.stack ?? err.message);
+  process.exit(1);
+});

--- a/lib/failover/cli_helpers.js
+++ b/lib/failover/cli_helpers.js
@@ -1,0 +1,36 @@
+/**
+ * Shared helpers used by failover submodules.
+ * Kept here to avoid circular imports between cli.js, pool.js, and monitor.js.
+ */
+
+import { readFileSync } from 'node:fs';
+
+/**
+ * Read the ANTHROPIC_AUTH_TOKEN from the systemd service unit file.
+ * Useful when the env var is not exported to the current process but is
+ * declared in the service unit's Environment= stanza.
+ *
+ * @returns {string|null}
+ */
+export function readCompatTokenFromUnit() {
+  try {
+    const unit = readFileSync('/etc/systemd/system/claude-failover.service', 'utf-8');
+    const m = unit.match(/^Environment=ANTHROPIC_AUTH_TOKEN=(.+)$/m);
+    if (m) return m[1].trim();
+  } catch {}
+  return null;
+}
+
+/**
+ * Read a secret from an authTokenFile path (systemd-creds, Docker secrets, etc.).
+ *
+ * @param {string} filePath
+ * @returns {string|null}
+ */
+export function readTokenFromFile(filePath) {
+  if (!filePath) return null;
+  try {
+    return readFileSync(filePath, 'utf-8').trim() || null;
+  } catch {}
+  return null;
+}

--- a/lib/failover/monitor.js
+++ b/lib/failover/monitor.js
@@ -33,7 +33,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from '
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 
-import { getBestProviderOrNull } from './pool.js';
+import { getBestProviderOrNull, buildCustomPeers } from './pool.js';
 
 const STATE_DIR = join(homedir(), '.claude-nonstop', 'state');
 const STATE_FILE = join(STATE_DIR, 'active.json');
@@ -100,6 +100,41 @@ function writeActiveState(state) {
   renameSync(tmp, STATE_FILE);
 }
 
+/**
+ * Resolve the connection block to persist in the state file.
+ *
+ * The state file MUST NOT contain the bearer token (AGE-71). When the monitor
+ * is switching to a custom peer, look up the peer's public connection info via
+ * `peersByName` rather than carrying `decision.connection` (which is the
+ * token-bearing `getConnectionInfo()` used only at spawn time). When parked on
+ * primary or no peer is in scope, return null — the runner reads the live
+ * failover.json at spawn time to resolve a token from authTokenEnv / file / unit.
+ *
+ * @param {object|null} decision
+ * @param {Map<string, import('./provider.js').CustomEndpointProvider>} peersByName
+ * @returns {{baseUrl: string, model: string, peer: string} | null}
+ */
+function resolveConnectionForState(decision, peersByName) {
+  if (!decision || !decision.peer) return null;
+  const peerName = decision.peer.startsWith('custom:')
+    ? decision.peer.slice('custom:'.length)
+    : decision.peer;
+  const peer = peersByName?.get(peerName);
+  if (peer) return peer.getPublicConnectionInfo();
+  // Fall back: best-effort public projection from the token-bearing object.
+  // This path is only hit if the config can't be re-resolved (e.g. dry-run on
+  // a peer whose config was deleted mid-tick). We strip the token explicitly
+  // rather than returning the raw object.
+  if (decision.connection) {
+    return {
+      baseUrl: decision.connection.baseUrl,
+      model: decision.connection.model,
+      peer: peerName,
+    };
+  }
+  return null;
+}
+
 function appendLog(line) {
   try {
     ensureDir(dirname(LOG_FILE));
@@ -133,16 +168,33 @@ function normalizeCurrentProvider(raw) {
  * @param {string} current - "primary" | "fallback" | "custom:<name>"
  * @param {{ best: { provider, reading }|null, bestPeer: import('./provider.js').CustomEndpointProvider|null, all: Array }} poolResult
  * @param {{ switch_at: number, switch_back_at: number }} thresholds
+ * @param {object} [opts]
+ * @param {Map<string, import('./provider.js').CustomEndpointProvider>} [opts.peersByName]
+ *   Lookup keyed by peer *config* name (without the `custom:` prefix). Used by
+ *   the switch-back path so per-peer `switch_back_at` overrides are honored
+ *   even after OAuth recovers (at which point bestPeer is null in the pool
+ *   result).
  * @returns {{ target: string, account?: string, peer?: string, connection?: object, reason: string } | null}
  */
-export function decide(current, poolResult, thresholds) {
+export function decide(current, poolResult, thresholds, opts = {}) {
   const { best, bestPeer, all } = poolResult;
+  const peersByName = opts.peersByName ?? null;
 
   const oauthAll = all.filter((a) => !a.isPeer);
   const errorCount = oauthAll.filter((a) => a.error).length;
   const bestPercent = best?.reading?.percent ?? null;
 
   const isOnCustom = current !== 'primary';
+
+  // Resolve the peer we're currently parked on (if any). On switch-back OAuth
+  // has recovered, so `bestPeer` from the pool is null — we still need to look
+  // up the *current* peer's threshold override to honor per-peer switch_back_at.
+  const currentPeerName = isOnCustom && current.startsWith('custom:')
+    ? current.slice('custom:'.length)
+    : null;
+  const currentPeer = currentPeerName
+    ? peersByName?.get(currentPeerName) ?? null
+    : null;
 
   if (oauthAll.length === 0) {
     if (isOnCustom) return null;
@@ -198,11 +250,16 @@ export function decide(current, poolResult, thresholds) {
   // Currently on a custom provider — decide whether to switch back.
   if (!best) return null;
 
-  // Use per-peer switch_back_at if the current peer has an override.
+  // Per-peer switch_back_at: prefer the override on the *current* peer (which
+  // may be null in the pool result after OAuth recovers). Fall back to bestPeer's
+  // override (only meaningful when bestPeer is set, e.g. legacy `fallback` path).
   let switchBackAt = thresholds.switch_back_at;
-  if (bestPeer) {
-    const override = bestPeer.thresholdOverrides()?.switch_back_at;
-    if (override != null) switchBackAt = override;
+  const currentOverride = currentPeer?.thresholdOverrides()?.switch_back_at;
+  const bestOverride = bestPeer?.thresholdOverrides()?.switch_back_at;
+  if (currentOverride != null) {
+    switchBackAt = currentOverride;
+  } else if (bestOverride != null) {
+    switchBackAt = bestOverride;
   }
 
   if (bestPercent != null && bestPercent <= switchBackAt) {
@@ -249,14 +306,26 @@ export class FailoverMonitor {
   async tick() {
     const poolResult = await getBestProviderOrNull(this._thresholds, this._cfg);
     const { provider: current, account: currentAccount } = this._readActive();
-    const decision = decide(current, poolResult, this._thresholds);
+
+    // Build a peer-name → provider map so decide() can resolve the *current*
+    // peer's threshold override on the switch-back path (bestPeer from the pool
+    // is null once OAuth has recovered).
+    const peersByName = new Map(
+      (this._cfg ? buildCustomPeers(this._cfg) : []).map((p) => [p._name, p])
+    );
+
+    const decision = decide(current, poolResult, this._thresholds, { peersByName });
 
     const bestPercent = poolResult.best?.reading?.percent ?? null;
     const oauthAll = poolResult.all.filter((a) => !a.isPeer);
     const allSummary = poolResult.all
-      .map((a) => `${a.name}=${a.percent ?? '?'}${a.error ? `(err=${a.error})` : ''}${a.isPeer ? '(peer)' : ''}`)
+      .map((a) => `${a.name}=${a.percent ?? '?'}${a.error ? `(err=${a.error})` : ''}${a.isPeer ? `(peer${a.healthy === false ? '/unhealthy' : ''})` : ''}`)
       .join(' ');
 
+    // State file MUST NOT contain the bearer token. resolveConnectionForState
+    // returns the public (token-free) form when the decision targets a custom
+    // peer; the runner re-resolves the token at spawn time from the configured
+    // source (authTokenEnv / authTokenFile / unit file).
     const targetProvider = decision ? decision.target : current;
     const state = {
       provider: targetProvider,
@@ -265,7 +334,7 @@ export class FailoverMonitor {
       at: new Date().toISOString(),
       primary_utilization: bestPercent,
       primary_account: poolResult.best?.provider.name() ?? null,
-      connection: decision?.connection ?? null,
+      connection: resolveConnectionForState(decision, peersByName),
       pool: poolResult.all,
       last_check: {
         at: new Date().toISOString(),

--- a/lib/failover/monitor.js
+++ b/lib/failover/monitor.js
@@ -1,0 +1,314 @@
+/**
+ * Failover state machine.
+ *
+ * Owns the active-provider decision. Polls the OAuth/custom pool on a timer
+ * (or synchronously via tick()), decides whether to switch, and atomically
+ * writes the active provider to a state file consumed by the runner/wrapper.
+ *
+ *   state file: ~/.claude-nonstop/state/active.json
+ *     {
+ *       "provider": "primary" | "custom:<name>",
+ *       "account":  "<oauth account name>" | null,
+ *       "reason":   string,
+ *       "at":       ISO-8601 timestamp,
+ *       "primary_utilization": 0-100 | null,
+ *       "last_check": { at, ok, percent, error },
+ *       "connection": { baseUrl, model } | null    -- set when on a custom peer
+ *     }
+ *
+ * Thresholds (configurable per-account and globally in failover.json):
+ *   switch_at:       best OAuth account >= X → switch to custom peer
+ *   switch_back_at:  best OAuth account <= Y → switch back to primary
+ *   recheck_interval_seconds: poll cadence (default 60)
+ *
+ * "Primary" = the OAuth account pool (all claude-nonstop registered accounts).
+ * The monitor picks the lowest-utilization OAuth account. If none are below
+ * threshold, it falls back to the first healthy custom endpoint peer.
+ *
+ * Hysteresis prevents flapping: once on a custom peer, only revert when the
+ * best OAuth drops well below the original trigger (switch_back_at, 50% default).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+
+import { getBestProviderOrNull } from './pool.js';
+
+const STATE_DIR = join(homedir(), '.claude-nonstop', 'state');
+const STATE_FILE = join(STATE_DIR, 'active.json');
+const LOG_FILE = join(homedir(), '.claude-nonstop', 'logs', 'failover.log');
+
+const DEFAULT_CONFIG = {
+  primary: null,
+  fallback: null,
+  peers: [],
+  thresholds: {
+    switch_at: 80,
+    switch_back_at: 50,
+    recheck_interval_seconds: 60,
+  },
+  logging: { path: LOG_FILE },
+};
+
+function ensureDir(p) {
+  if (!existsSync(p)) mkdirSync(p, { recursive: true });
+}
+
+export function loadFailoverConfig(configPath) {
+  if (!configPath || !existsSync(configPath)) return structuredClone(DEFAULT_CONFIG);
+  try {
+    const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+    // Normalize legacy threshold keys for backward compatibility
+    const mergedThresholds = { ...DEFAULT_CONFIG.thresholds };
+    if (raw.thresholds) {
+      mergedThresholds.switch_at = raw.thresholds.switch_at
+        ?? raw.thresholds.switch_to_fallback_at
+        ?? DEFAULT_CONFIG.thresholds.switch_at;
+      mergedThresholds.switch_back_at = raw.thresholds.switch_back_at
+        ?? DEFAULT_CONFIG.thresholds.switch_back_at;
+      mergedThresholds.recheck_interval_seconds = raw.thresholds.recheck_interval_seconds
+        ?? DEFAULT_CONFIG.thresholds.recheck_interval_seconds;
+    }
+
+    return {
+      ...structuredClone(DEFAULT_CONFIG),
+      ...raw,
+      thresholds: mergedThresholds,
+      logging: { ...DEFAULT_CONFIG.logging, ...(raw.logging ?? {}) },
+      peers: Array.isArray(raw.peers) ? raw.peers : [],
+    };
+  } catch {
+    return structuredClone(DEFAULT_CONFIG);
+  }
+}
+
+export function loadActiveState() {
+  if (!existsSync(STATE_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(STATE_FILE, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeActiveState(state) {
+  ensureDir(dirname(STATE_FILE));
+  const tmp = `${STATE_FILE}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, STATE_FILE);
+}
+
+function appendLog(line) {
+  try {
+    ensureDir(dirname(LOG_FILE));
+    const ts = new Date().toISOString();
+    const full = `[${ts}] ${line}\n`;
+    const prev = existsSync(LOG_FILE) ? readFileSync(LOG_FILE, 'utf-8') : '';
+    const trimmed = prev.length > 64_000 ? prev.slice(-32_000) : prev;
+    writeFileSync(LOG_FILE, trimmed + full, { mode: 0o600 });
+  } catch {
+    // Logging must never break failover.
+  }
+}
+
+/**
+ * Normalise the current provider string from the state file.
+ *
+ * @param {string} raw
+ * @returns {"primary"|string} "primary" or "custom:<name>" (or legacy "fallback")
+ */
+function normalizeCurrentProvider(raw) {
+  if (!raw || raw === 'primary') return 'primary';
+  if (raw === 'fallback') return 'fallback'; // legacy compat
+  if (raw.startsWith('custom:')) return raw;
+  if (raw.startsWith('peer:')) return raw.replace('peer:', 'custom:'); // legacy
+  return 'primary';
+}
+
+/**
+ * Decide target provider from current state and a fresh pool reading.
+ *
+ * @param {string} current - "primary" | "fallback" | "custom:<name>"
+ * @param {{ best: { provider, reading }|null, bestPeer: import('./provider.js').CustomEndpointProvider|null, all: Array }} poolResult
+ * @param {{ switch_at: number, switch_back_at: number }} thresholds
+ * @returns {{ target: string, account?: string, peer?: string, connection?: object, reason: string } | null}
+ */
+export function decide(current, poolResult, thresholds) {
+  const { best, bestPeer, all } = poolResult;
+
+  const oauthAll = all.filter((a) => !a.isPeer);
+  const errorCount = oauthAll.filter((a) => a.error).length;
+  const bestPercent = best?.reading?.percent ?? null;
+
+  const isOnCustom = current !== 'primary';
+
+  if (oauthAll.length === 0) {
+    if (isOnCustom) return null;
+    if (bestPeer) {
+      return {
+        target: bestPeer.name(),
+        peer: bestPeer.name(),
+        connection: bestPeer.getConnectionInfo(),
+        reason: 'no_oauth_accounts',
+      };
+    }
+    return null;
+  }
+
+  if (current === 'primary') {
+    if (!best) {
+      // All OAuth exhausted — pick best peer
+      if (bestPeer) {
+        return {
+          target: bestPeer.name(),
+          peer: bestPeer.name(),
+          connection: bestPeer.getConnectionInfo(),
+          reason: 'all_oauth_above_threshold',
+        };
+      }
+      return null;
+    }
+    if (bestPercent != null && bestPercent >= thresholds.switch_at) {
+      if (bestPeer) {
+        return {
+          target: bestPeer.name(),
+          peer: bestPeer.name(),
+          connection: bestPeer.getConnectionInfo(),
+          reason: `best_oauth_at_${bestPercent}pct`,
+        };
+      }
+      return null;
+    }
+    if (errorCount === oauthAll.length) {
+      if (bestPeer) {
+        return {
+          target: bestPeer.name(),
+          peer: bestPeer.name(),
+          connection: bestPeer.getConnectionInfo(),
+          reason: 'all_oauth_erroring',
+        };
+      }
+      return null;
+    }
+    return null;
+  }
+
+  // Currently on a custom provider — decide whether to switch back.
+  if (!best) return null;
+
+  // Use per-peer switch_back_at if the current peer has an override.
+  let switchBackAt = thresholds.switch_back_at;
+  if (bestPeer) {
+    const override = bestPeer.thresholdOverrides()?.switch_back_at;
+    if (override != null) switchBackAt = override;
+  }
+
+  if (bestPercent != null && bestPercent <= switchBackAt) {
+    return {
+      target: 'primary',
+      account: best.provider.name(),
+      reason: `best_oauth_recovered_${bestPercent}pct_${best.provider.name()}`,
+    };
+  }
+  return null;
+}
+
+export class FailoverMonitor {
+  /**
+   * @param {{
+   *   thresholds: { switch_at: number, switch_back_at: number, recheck_interval_seconds: number },
+   *   cfg?: object,
+   *   log?: (line: string) => void,
+   *   statePath?: string,
+   * }} opts
+   */
+  constructor({ thresholds, cfg, log, statePath }) {
+    this._thresholds = thresholds;
+    this._cfg = cfg ?? null;
+    this._log = log ?? appendLog;
+    this._statePath = statePath ?? STATE_FILE;
+    this._timer = null;
+    this._stopped = false;
+  }
+
+  _readActive() {
+    if (!existsSync(this._statePath)) return { provider: 'primary', account: null };
+    try {
+      const s = JSON.parse(readFileSync(this._statePath, 'utf-8'));
+      return {
+        provider: normalizeCurrentProvider(s.provider),
+        account: s.account ?? null,
+      };
+    } catch {
+      return { provider: 'primary', account: null };
+    }
+  }
+
+  async tick() {
+    const poolResult = await getBestProviderOrNull(this._thresholds, this._cfg);
+    const { provider: current, account: currentAccount } = this._readActive();
+    const decision = decide(current, poolResult, this._thresholds);
+
+    const bestPercent = poolResult.best?.reading?.percent ?? null;
+    const oauthAll = poolResult.all.filter((a) => !a.isPeer);
+    const allSummary = poolResult.all
+      .map((a) => `${a.name}=${a.percent ?? '?'}${a.error ? `(err=${a.error})` : ''}${a.isPeer ? '(peer)' : ''}`)
+      .join(' ');
+
+    const targetProvider = decision ? decision.target : current;
+    const state = {
+      provider: targetProvider,
+      account: (decision?.account ?? poolResult.best?.provider.name() ?? currentAccount) ?? null,
+      reason: decision?.reason ?? (current !== 'primary' ? `on_${current}` : 'on_primary'),
+      at: new Date().toISOString(),
+      primary_utilization: bestPercent,
+      primary_account: poolResult.best?.provider.name() ?? null,
+      connection: decision?.connection ?? null,
+      pool: poolResult.all,
+      last_check: {
+        at: new Date().toISOString(),
+        ok: oauthAll.some((a) => !a.error),
+        percent: bestPercent,
+        error: oauthAll.find((a) => a.error)?.error ?? null,
+      },
+    };
+
+    writeActiveState(state);
+
+    if (decision) {
+      this._log(
+        `SWITCH ${current}→${decision.target} account=${state.account ?? '-'} ` +
+        `reason=${decision.reason} best=${bestPercent ?? '?'}% | ${allSummary}`
+      );
+    } else {
+      this._log(
+        `CHECK active=${state.provider} account=${state.account ?? '-'} ` +
+        `best=${bestPercent ?? '?'}% | ${allSummary}`
+      );
+    }
+
+    return state;
+  }
+
+  start() {
+    if (this._timer) return;
+    this._stopped = false;
+    const intervalMs = Math.max(30, this._thresholds.recheck_interval_seconds) * 1000;
+    this.tick().catch((err) => this._log(`TICK_ERROR ${err.message}`));
+    this._timer = setInterval(() => {
+      if (this._stopped) return;
+      this.tick().catch((err) => this._log(`TICK_ERROR ${err.message}`));
+    }, intervalMs);
+    if (typeof this._timer.unref === 'function') this._timer.unref();
+  }
+
+  stop() {
+    this._stopped = true;
+    if (this._timer) clearInterval(this._timer);
+    this._timer = null;
+  }
+}
+
+export { STATE_FILE, LOG_FILE };

--- a/lib/failover/pool.js
+++ b/lib/failover/pool.js
@@ -226,17 +226,32 @@ export async function getBestProviderOrNull(thresholds, cfg) {
   // Only evaluate peers when OAuth is exhausted (or missing).
   const bestPeer = bestOAuth ? null : await pickBestPeer(peers, thresholds);
 
+  // Probe peer health in parallel for the `all` summary so `failover status`,
+  // `dry-run`, and the monitor's persisted `pool` block reflect real reachability
+  // rather than the previous hardcoded {percent:0, error:null, isPeer:true}.
+  const peerHealth = await Promise.all(
+    peers.map(async (p) => {
+      try {
+        const healthy = await p.isHealthy();
+        return { provider: p, healthy };
+      } catch {
+        return { provider: p, healthy: false };
+      }
+    })
+  );
+
   const allSummary = [
     ...readings.map((r) => ({
       name: r.provider.name(),
       percent: r.reading.percent,
       error: r.reading.error,
     })),
-    ...peers.map((p) => ({
-      name: p.name(),
+    ...peerHealth.map(({ provider, healthy }) => ({
+      name: provider.name(),
       percent: 0,
-      error: null,
+      error: healthy ? null : 'unhealthy',
       isPeer: true,
+      healthy,
     })),
   ];
 

--- a/lib/failover/pool.js
+++ b/lib/failover/pool.js
@@ -1,0 +1,244 @@
+/**
+ * Unified provider pool — OAuth accounts + custom endpoint peers.
+ *
+ * The pool fetches utilization for all registered OAuth accounts in parallel
+ * and returns the best healthy one (lowest effective utilization below
+ * threshold). When all OAuth accounts are above threshold, the pool falls
+ * back to the first healthy custom endpoint peer, ordered by per-peer
+ * switch_at ascending (the peer that activates at the lowest OAuth
+ * utilization takes priority).
+ *
+ * Each account (OAuth or custom) can carry per-account threshold overrides:
+ *   { switch_at: number, switch_back_at: number }
+ *
+ * Legacy single-fallback configs (a single `fallback` entry with no `peers`
+ * array) are transparently promoted to the peers array so all code paths
+ * converge on the same multi-peer logic.
+ */
+
+import { OAuthProvider, CustomEndpointProvider } from './provider.js';
+import { readCredentials } from '../keychain.js';
+import { loadConfig } from '../config.js';
+import { readCompatTokenFromUnit, readTokenFromFile } from './cli_helpers.js';
+
+function resolveToken(configDir) {
+  try {
+    const creds = readCredentials(configDir);
+    return creds?.token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build OAuthProvider instances from all registered claude-nonstop accounts.
+ *
+ * Per-account thresholds are read from the account's entry in config.json
+ * (set via `claude-nonstop set-threshold <name> <switch_at> <switch_back_at>`
+ * or by editing config.json directly).
+ *
+ * @returns {OAuthProvider[]}
+ */
+export function buildAllOAuthProviders() {
+  const accounts = loadConfig().accounts ?? [];
+  return accounts.map((a) => new OAuthProvider({
+    name: a.name,
+    configDir: a.configDir,
+    getToken: resolveToken,
+    thresholds: a.thresholds ?? null,
+  }));
+}
+
+/**
+ * Resolve the API token for a custom endpoint peer entry.
+ *
+ * Resolution order:
+ *   1. Literal `authToken` in config (for quick testing).
+ *   2. `authTokenFile` — read from a file (systemd-creds, Docker secrets).
+ *   3. `authTokenEnv` environment variable (default: ANTHROPIC_AUTH_TOKEN).
+ *   4. Systemd unit file fallback (claude-failover.service).
+ *
+ * @param {object} peerCfg
+ * @returns {string}
+ */
+function resolveCustomToken(peerCfg) {
+  if (peerCfg.authToken) return peerCfg.authToken;
+  if (peerCfg.authTokenFile) {
+    const fromFile = readTokenFromFile(peerCfg.authTokenFile);
+    if (fromFile) return fromFile;
+  }
+  const envVar = peerCfg.authTokenEnv ?? 'ANTHROPIC_AUTH_TOKEN';
+  return process.env[envVar] ?? readCompatTokenFromUnit() ?? '';
+}
+
+/**
+ * Build CustomEndpointProvider instances from the `peers` array in failover.json.
+ *
+ * Each peer entry:
+ *   {
+ *     name: string,             // required — used as custom:<name>
+ *     kind: "custom_endpoint",  // required (or "anthropic_compat" for legacy)
+ *     baseUrl: string,          // required
+ *     authTokenEnv?: string,    // env var (default: ANTHROPIC_AUTH_TOKEN)
+ *     authToken?: string,       // literal token
+ *     authTokenFile?: string,   // file path (systemd-creds / Docker secrets)
+ *     model?: string,           // default: "auto"
+ *     thresholds?: {
+ *       switch_at?: number,
+ *       switch_back_at?: number,
+ *     }
+ *   }
+ *
+ * @param {object} cfg - Full failover config
+ * @returns {CustomEndpointProvider[]}
+ */
+export function buildCustomPeers(cfg) {
+  const peers = normalizePeers(cfg);
+  return peers
+    .filter((p) => p.name && p.baseUrl)
+    .map((p) => new CustomEndpointProvider({
+      name: p.name,
+      baseUrl: p.baseUrl,
+      token: resolveCustomToken(p),
+      model: p.model ?? 'auto',
+      thresholds: p.thresholds ?? null,
+    }));
+}
+
+/**
+ * Merge the legacy single `fallback` entry into the peers array if present.
+ * Returns a unified peers list. Does NOT mutate the original config.
+ */
+function normalizePeers(cfg) {
+  const peers = [...(Array.isArray(cfg.peers) ? cfg.peers : [])];
+  // Promote legacy fallback to a peer named "_fallback" if not already in peers.
+  if (cfg.fallback?.baseUrl && !peers.some((p) => p.name === '_fallback')) {
+    peers.unshift({
+      name: '_fallback',
+      kind: cfg.fallback.kind ?? 'custom_endpoint',
+      baseUrl: cfg.fallback.baseUrl,
+      authTokenEnv: cfg.fallback.authTokenEnv,
+      authToken: cfg.fallback.authToken,
+      authTokenFile: cfg.fallback.authTokenFile,
+      model: cfg.fallback.model,
+      thresholds: cfg.fallback.thresholds ?? null,
+    });
+  }
+  return peers;
+}
+
+/**
+ * Read all account utilizations in parallel.
+ */
+export async function readAllUtilizations(providers) {
+  return Promise.all(
+    providers.map(async (provider) => {
+      const reading = await provider.getUtilization();
+      return { provider, reading };
+    })
+  );
+}
+
+/**
+ * Pick the best primary OAuth account below threshold.
+ *
+ * Uses per-account threshold overrides when set; falls back to global.
+ *
+ * @param {Array<{ provider: OAuthProvider, reading }>} readings
+ * @param {{ switch_at: number }} globalThresholds
+ * @returns {{ provider, reading } | null}
+ */
+export function pickBestOAuth(readings, globalThresholds) {
+  const scored = readings.map((r) => {
+    let score;
+    if (r.reading.error) {
+      score = 100;
+    } else if (r.reading.percent == null) {
+      score = -1; // unknown — prefer over known-exhausted
+    } else {
+      score = r.reading.percent;
+    }
+    return { ...r, score };
+  });
+
+  scored.sort((a, b) => a.score - b.score);
+
+  const best = scored[0];
+  const threshold = best.provider.thresholdOverrides()?.switch_at
+    ?? globalThresholds.switch_at;
+
+  if (best.score >= threshold) return null;
+  return { provider: best.provider, reading: best.reading };
+}
+
+/**
+ * Pick the best healthy custom endpoint peer.
+ *
+ * Peers are ordered by their per-account `switch_at` ascending — the peer
+ * that activates at the lowest OAuth utilization takes priority. Among peers
+ * at the same threshold, the one listed first in config wins.
+ *
+ * @param {CustomEndpointProvider[]} peers
+ * @param {{ switch_at: number }} globalThresholds
+ * @returns {Promise<CustomEndpointProvider | null>}
+ */
+export async function pickBestPeer(peers, globalThresholds) {
+  if (!peers || peers.length === 0) return null;
+
+  const sorted = [...peers].sort((a, b) => {
+    const aAt = a.thresholdOverrides()?.switch_at ?? globalThresholds.switch_at;
+    const bAt = b.thresholdOverrides()?.switch_at ?? globalThresholds.switch_at;
+    return aAt - bAt;
+  });
+
+  for (const peer of sorted) {
+    if (await peer.isHealthy()) return peer;
+  }
+  return null;
+}
+
+/**
+ * Merged pool lookup: OAuth accounts + custom endpoint peers.
+ *
+ * Returns the best OAuth provider if any are below threshold, or else the
+ * first healthy custom endpoint peer.
+ *
+ * @param {{ switch_at: number, switch_back_at: number }} thresholds
+ * @param {object} [cfg] - Full failover config (for peers)
+ * @returns {Promise<{
+ *   best: { provider, reading } | null,
+ *   bestPeer: CustomEndpointProvider | null,
+ *   all: Array<{ name, percent, error, isPeer? }>
+ * }>}
+ */
+export async function getBestProviderOrNull(thresholds, cfg) {
+  const oauthProviders = buildAllOAuthProviders();
+  const peers = cfg ? buildCustomPeers(cfg) : [];
+
+  const readings = oauthProviders.length > 0
+    ? await readAllUtilizations(oauthProviders)
+    : [];
+
+  const bestOAuth = readings.length > 0
+    ? pickBestOAuth(readings, thresholds)
+    : null;
+
+  // Only evaluate peers when OAuth is exhausted (or missing).
+  const bestPeer = bestOAuth ? null : await pickBestPeer(peers, thresholds);
+
+  const allSummary = [
+    ...readings.map((r) => ({
+      name: r.provider.name(),
+      percent: r.reading.percent,
+      error: r.reading.error,
+    })),
+    ...peers.map((p) => ({
+      name: p.name(),
+      percent: 0,
+      error: null,
+      isPeer: true,
+    })),
+  ];
+
+  return { best: bestOAuth, bestPeer, all: allSummary };
+}

--- a/lib/failover/provider.js
+++ b/lib/failover/provider.js
@@ -1,0 +1,182 @@
+/**
+ * Provider abstraction for the failover layer.
+ *
+ * Three concrete providers:
+ *
+ *   OAuthProvider         Primary tier. Reads utilization from the Anthropic
+ *                         OAuth usage API. Backed by claude-nonstop's keychain
+ *                         credential store (one OAuth token per configDir).
+ *
+ *   CustomEndpointProvider  An Anthropic-API-compatible endpoint identified by
+ *                         (baseUrl + API key). Can be a single legacy
+ *                         `fallback` OR one of many named `peers` in the pool.
+ *                         Health checked via GET <baseUrl>/v1/models. Has no
+ *                         Anthropic-side quota view, so utilization is always 0.
+ *                         Carries optional per-account threshold overrides.
+ *
+ * Each provider exposes:
+ *   name()              - Short identifier for logging / state file
+ *   getUtilization()    - { percent: 0-100|null, error: string|null, ... }
+ *   isHealthy()         - Boolean, true when a recent probe succeeded
+ *   describe()          - Human-readable one-liner for logs
+ *   thresholdOverrides()- { switch_at?, switch_back_at? } | null
+ *   kind()              - "oauth" | "custom_endpoint"
+ */
+
+const FETCH_TIMEOUT_MS = 8_000;
+
+function normalizePercent(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 0;
+  if (value >= 0 && value <= 1) return Math.round(value * 100);
+  return Math.round(value);
+}
+
+async function fetchWithTimeout(url, init = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ─── OAuth Provider ────────────────────────────────────────────────────────
+
+export class OAuthProvider {
+  /**
+   * @param {{
+   *   name: string,
+   *   configDir: string,
+   *   getToken: (configDir: string) => string|null,
+   *   thresholds?: { switch_at?: number, switch_back_at?: number }
+   * }} opts
+   */
+  constructor({ name, configDir, getToken, thresholds }) {
+    this._name = name;
+    this._configDir = configDir;
+    this._getToken = getToken;
+    this._thresholds = thresholds ?? null;
+  }
+
+  kind() { return 'oauth'; }
+
+  name() { return `oauth:${this._name}`; }
+
+  thresholdOverrides() { return this._thresholds; }
+
+  async getUtilization() {
+    const token = this._getToken(this._configDir);
+    if (!token) return { percent: null, error: 'no_token' };
+
+    try {
+      const res = await fetchWithTimeout('https://api.anthropic.com/api/oauth/usage', {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'anthropic-beta': 'oauth-2025-04-20',
+          'anthropic-version': '2023-06-01',
+          'Content-Type': 'application/json',
+        },
+      });
+      if (res.status === 401 || res.status === 403) {
+        return { percent: null, error: `auth_${res.status}` };
+      }
+      if (res.status === 429) {
+        return { percent: 100, error: null, hint: 'usage_endpoint_429' };
+      }
+      if (!res.ok) {
+        return { percent: null, error: `http_${res.status}` };
+      }
+      const data = await res.json();
+      const session = data.five_hour?.utilization ?? data.five_hour_utilization ?? 0;
+      const weekly = data.seven_day?.utilization ?? data.seven_day_utilization ?? 0;
+      return {
+        percent: Math.max(normalizePercent(session), normalizePercent(weekly)),
+        error: null,
+        sessionResetsAt: data.five_hour?.resets_at ?? data.five_hour_reset_at ?? null,
+        weeklyResetsAt: data.seven_day?.resets_at ?? data.seven_day_reset_at ?? null,
+      };
+    } catch (err) {
+      return { percent: null, error: err.name === 'AbortError' ? 'timeout' : err.message };
+    }
+  }
+
+  async isHealthy() {
+    const u = await this.getUtilization();
+    return u.error == null && (u.percent == null || u.percent < 100);
+  }
+
+  describe(u) {
+    const reading = u ?? null;
+    const pct = reading?.percent == null ? '?' : `${reading.percent}%`;
+    return `oauth:${this._name} util=${pct}${reading?.error ? ` err=${reading.error}` : ''}`;
+  }
+}
+
+// ─── Custom Endpoint Provider ──────────────────────────────────────────────
+
+export class CustomEndpointProvider {
+  /**
+   * @param {{
+   *   name: string,
+   *   baseUrl: string,
+   *   token: string,
+   *   model?: string,
+   *   thresholds?: { switch_at?: number, switch_back_at?: number }
+   * }} opts
+   */
+  constructor({ name, baseUrl, token, model, thresholds }) {
+    this._name = name;
+    this._baseUrl = baseUrl.replace(/\/+$/, '');
+    this._token = token;
+    this._model = model ?? 'auto';
+    this._thresholds = thresholds ?? null;
+    this._lastHealthAt = 0;
+    this._lastHealthy = false;
+  }
+
+  kind() { return 'custom_endpoint'; }
+
+  name() { return `custom:${this._name}`; }
+
+  thresholdOverrides() { return this._thresholds; }
+
+  /**
+   * Custom endpoints have no Anthropic-side quota view.
+   * Convention: 0% (unlimited from our perspective), with `unknown: true`.
+   */
+  async getUtilization() {
+    return { percent: 0, error: null, unknown: true };
+  }
+
+  async isHealthy() {
+    const now = Date.now();
+    if (now - this._lastHealthAt < 30_000) return this._lastHealthy;
+    this._lastHealthAt = now;
+    try {
+      const res = await fetchWithTimeout(`${this._baseUrl}/v1/models`, {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${this._token}` },
+      });
+      this._lastHealthy = res.ok;
+      return res.ok;
+    } catch {
+      this._lastHealthy = false;
+      return false;
+    }
+  }
+
+  describe() {
+    return `custom:${this._name} model=${this._model} base=${this._baseUrl}`;
+  }
+
+  /** Expose connection details so the runner can set env vars. */
+  getConnectionInfo() {
+    return {
+      baseUrl: this._baseUrl,
+      token: this._token,
+      model: this._model,
+    };
+  }
+}

--- a/lib/failover/provider.js
+++ b/lib/failover/provider.js
@@ -171,12 +171,33 @@ export class CustomEndpointProvider {
     return `custom:${this._name} model=${this._model} base=${this._baseUrl}`;
   }
 
-  /** Expose connection details so the runner can set env vars. */
+  /**
+   * Expose full connection details (including the bearer token) so the runner
+   * can set ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN before spawning `claude`.
+   *
+   * RUNTIME ONLY — never persist this object. The token must not be written to
+   * the state file on disk. Use getPublicConnectionInfo() for anything that is
+   * serialized (state file, `failover status`, logs).
+   */
   getConnectionInfo() {
     return {
       baseUrl: this._baseUrl,
       token: this._token,
       model: this._model,
+    };
+  }
+
+  /**
+   * Token-free connection info safe to persist to the state file or print in
+   * `failover status`. The runner re-resolves the token at spawn time from the
+   * configured source (authTokenEnv / authTokenFile / unit file), so the token
+   * never needs to live on disk.
+   */
+  getPublicConnectionInfo() {
+    return {
+      baseUrl: this._baseUrl,
+      model: this._model,
+      peer: this._name,
     };
   }
 }

--- a/lib/keychain.js
+++ b/lib/keychain.js
@@ -64,7 +64,7 @@ export function expandPath(p) {
 export function getServiceName(configDir) {
   const expanded = expandPath(configDir);
 
-  if (expanded === DEFAULT_CLAUDE_DIR) {
+  if (expanded === DEFAULT_CLAUDE_DIR()) {
     return 'Claude Code-credentials';
   }
 

--- a/lib/reauth.js
+++ b/lib/reauth.js
@@ -46,7 +46,7 @@ export async function reauthAccount(account) {
   // hashed entry but readCredentials reads from the standard one.
   const authEnv = { ...process.env };
   delete authEnv.CLAUDECODE;
-  if (account.configDir === DEFAULT_CLAUDE_DIR) {
+  if (account.configDir === DEFAULT_CLAUDE_DIR()) {
     delete authEnv.CLAUDE_CONFIG_DIR;
   } else {
     authEnv.CLAUDE_CONFIG_DIR = account.configDir;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -190,7 +190,7 @@ function sleep(ms) {
  */
 function deactivateStaleChannels(tmuxSessionName, channelMapPath) {
   if (!channelMapPath) {
-    channelMapPath = path.join(CONFIG_DIR, 'data', 'channel-map.json');
+    channelMapPath = path.join(CONFIG_DIR(), 'data', 'channel-map.json');
   }
   try {
     if (!fs.existsSync(channelMapPath)) return;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -25,6 +25,7 @@ import { findLatestSession, migrateSession } from './session.js';
 import { reauthExpiredAccounts } from './reauth.js';
 import { CONFIG_DIR } from './config.js';
 import { getCurrentTmuxSession } from './tmux.js';
+import { resolveProvider } from './failover/active.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const HOOK_NOTIFY_PATH = path.resolve(__dirname, '..', 'remote', 'hook-notify.cjs');
@@ -473,7 +474,7 @@ export async function run(claudeArgs, selectedAccount, allAccounts, options = {}
  * @returns {Promise<{ exitCode: number|null, rateLimitDetected: boolean, resetTime: string|null, sessionId: string|null, preemptDetected: boolean, preemptTo: object|null, preemptReason: string|null }>}
  */
 function runOnce(claudeArgs, account, existingSessionId, options = {}) {
-  return new Promise((resolve) => {
+  return new Promise(async (resolve) => {
     const env = {
       ...process.env,
       CLAUDE_CONFIG_DIR: account.configDir,
@@ -486,6 +487,26 @@ function runOnce(claudeArgs, account, existingSessionId, options = {}) {
     if (options.remoteAccess) {
       env.CLAUDE_REMOTE_ACCESS = 'true';
     }
+
+    // Apply failover-driven env vars (custom endpoint peers). This handles
+    // both the monitor's choice and the non-TTY auto-promote path in one
+    // place, so the spawned `claude` always sees the right ANTHROPIC_BASE_URL
+    // and ANTHROPIC_AUTH_TOKEN regardless of how the decision was reached.
+    try {
+      const providerInfo = await resolveProvider({ isInteractive: Boolean(process.stdin?.isTTY) });
+      if (providerInfo?.connection) {
+        env.ANTHROPIC_BASE_URL = providerInfo.connection.baseUrl;
+        env.ANTHROPIC_AUTH_TOKEN = providerInfo.connection.token;
+        if (providerInfo.connection.model && providerInfo.connection.model !== 'auto') {
+          env.ANTHROPIC_MODEL = providerInfo.connection.model;
+        }
+        // Force pure fallback behavior — don't let OAuth creds leak through.
+        env.CLAUDE_CONFIG_DIR = '/dev/null';
+        if (providerInfo.autoPromoted) {
+          console.error(`[claude-nonstop] Auto-promoted to ${providerInfo.provider} (${providerInfo.reason})`);
+        }
+      }
+    } catch {}
 
     const child = pty.spawn('claude', claudeArgs, {
       name: 'xterm-256color',

--- a/lib/service.js
+++ b/lib/service.js
@@ -12,7 +12,7 @@ const PROJECT_ROOT = join(__dirname, '..');
 
 const SERVICE_LABEL = 'claude-nonstop-slack';
 const PLIST_PATH = join(homedir(), 'Library', 'LaunchAgents', `${SERVICE_LABEL}.plist`);
-const LOG_DIR = join(CONFIG_DIR, 'logs');
+const LOG_DIR = join(CONFIG_DIR(), 'logs');
 const LOG_PATH = join(LOG_DIR, 'webhook.log');
 
 /**

--- a/test/helpers/temp-home.js
+++ b/test/helpers/temp-home.js
@@ -1,0 +1,36 @@
+/**
+ * Temp HOME helpers for tests that need to redirect ~/.claude-nonstop writes.
+ *
+ * The v0.4.0 main branch doesn't ship a tmpHome helper yet — this file adds
+ * one for the failover tests.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+
+let savedHome = null;
+let tmpHomeDir = null;
+
+export function tmpHome(prefix = 'cns-test-home-') {
+  if (savedHome) return tmpHomeDir;
+  savedHome = process.env.HOME ?? homedir();
+  tmpHomeDir = mkdtempSync(join(tmpdir(), prefix));
+  process.env.HOME = tmpHomeDir;
+  return tmpHomeDir;
+}
+
+export function getTmpHomePath() {
+  return tmpHomeDir;
+}
+
+export function restoreHome() {
+  if (savedHome != null) {
+    process.env.HOME = savedHome;
+    savedHome = null;
+    if (tmpHomeDir) {
+      try { rmSync(tmpHomeDir, { recursive: true, force: true }); } catch {}
+    }
+    tmpHomeDir = null;
+  }
+}

--- a/test/unit/failover/active.test.js
+++ b/test/unit/failover/active.test.js
@@ -1,0 +1,141 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { tmpHome, restoreHome } from '../../helpers/temp-home.js';
+
+/**
+ * Tests for lib/failover/active.js — the non-TTY auto-promote behavior.
+ *
+ * We mock `resolveProvider` indirectly by pointing HOME at a tempdir where we
+ * write the active.json state file and failover.json config. We stub fetch
+ * so the health check doesn't actually hit a network.
+ *
+ * Because active.js eagerly resolves the failover config and builds peers,
+ * we need to be careful about which paths run synchronously vs async.
+ */
+
+let savedFetch;
+
+describe('failover/active.js — resolveProvider (non-TTY auto-promote)', () => {
+  before(() => {
+    tmpHome();
+    savedFetch = globalThis.fetch;
+    // Stub fetch so peer.isHealthy() doesn't hit the network
+    globalThis.fetch = async (url) => {
+      // Only the peer health probe should reach here; everything else is
+      // local to the test. We return 200 for /v1/models endpoints.
+      if (typeof url === 'string' && url.includes('/v1/models')) {
+        return new Response('', { status: 200 });
+      }
+      return new Response('', { status: 200 });
+    };
+  });
+
+  after(() => {
+    restoreHome();
+    if (savedFetch) globalThis.fetch = savedFetch;
+  });
+
+  it('returns primary in interactive mode with no state file', async () => {
+    const { resolveProvider } = await import('../../../lib/failover/active.js');
+    const r = await resolveProvider({ isInteractive: true });
+    assert.equal(r.provider, 'primary');
+    assert.equal(r.autoPromoted, false);
+  });
+
+  it('auto-promotes to first healthy peer in non-interactive mode', async () => {
+    // Set up a failover.json with one custom peer
+    const cfgDir = join(process.env.HOME, '.claude-nonstop');
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, 'failover.json'), JSON.stringify({
+      peers: [
+        { name: 'p1', baseUrl: 'https://p1.example.com', authToken: 'tok-p1' },
+      ],
+      thresholds: { switch_at: 80, switch_back_at: 50 },
+    }));
+
+    const { resolveProvider } = await import('../../../lib/failover/active.js');
+    const r = await resolveProvider({ isInteractive: false });
+    assert.equal(r.autoPromoted, true);
+    assert.equal(r.provider, 'custom:p1');
+    assert.equal(r.connection.baseUrl, 'https://p1.example.com');
+    assert.equal(r.connection.token, 'tok-p1');
+  });
+
+  it('does NOT auto-promote when a state file already says custom:<other>', async () => {
+    // State file says we're on custom:p2 (already decided). Non-TTY mode
+    // should honor that decision, not auto-promote to p1.
+    const cfgDir = join(process.env.HOME, '.claude-nonstop');
+    mkdirSync(join(cfgDir, 'state'), { recursive: true });
+    writeFileSync(join(cfgDir, 'failover.json'), JSON.stringify({
+      peers: [
+        { name: 'p1', baseUrl: 'https://p1.example.com', authToken: 'tok-p1' },
+        { name: 'p2', baseUrl: 'https://p2.example.com', authToken: 'tok-p2' },
+      ],
+    }));
+    writeFileSync(join(cfgDir, 'state', 'active.json'), JSON.stringify({
+      provider: 'custom:p2',
+      account: null,
+      connection: { baseUrl: 'https://p2.example.com', token: 'tok-p2', model: 'auto' },
+      reason: 'monitor_decision',
+      at: new Date().toISOString(),
+    }));
+
+    const { resolveProvider } = await import('../../../lib/failover/active.js');
+    const r = await resolveProvider({ isInteractive: false });
+    assert.equal(r.autoPromoted, false);
+    assert.equal(r.provider, 'custom:p2');
+    assert.equal(r.connection.token, 'tok-p2');
+  });
+
+  it('returns primary when no state file AND no peers AND interactive', async () => {
+    // No state file at all → return primary.
+    const stateFile = join(process.env.HOME, '.claude-nonstop', 'state', 'active.json');
+    try { unlinkSync(stateFile); } catch {}
+    writeFileSync(join(process.env.HOME, '.claude-nonstop', 'failover.json'), JSON.stringify({ peers: [], thresholds: {} }));
+
+    const { resolveProvider } = await import('../../../lib/failover/active.js');
+    const r = await resolveProvider({ isInteractive: true });
+    assert.equal(r.provider, 'primary');
+    assert.equal(r.autoPromoted, false);
+  });
+
+  it('falls through to primary in non-TTY mode when no peers are configured', async () => {
+    // State file says primary → no auto-promote happens (state honors monitor decision).
+    writeFileSync(join(process.env.HOME, '.claude-nonstop', 'state', 'active.json'),
+      JSON.stringify({ provider: 'primary', account: null, connection: null, reason: 'on_primary', at: new Date().toISOString() }));
+    writeFileSync(join(process.env.HOME, '.claude-nonstop', 'failover.json'), JSON.stringify({ peers: [] }));
+
+    const { resolveProvider } = await import('../../../lib/failover/active.js');
+    const r = await resolveProvider({ isInteractive: false });
+    // No peers → can't auto-promote → primary (which will prompt OAuth, but
+    // that's the only option left).
+    assert.equal(r.provider, 'primary');
+    assert.equal(r.autoPromoted, false);
+  });
+
+  it('honors state file in interactive mode (does NOT auto-promote)', async () => {
+    const cfgDir = join(process.env.HOME, '.claude-nonstop');
+    mkdirSync(join(cfgDir, 'state'), { recursive: true });
+    writeFileSync(join(cfgDir, 'failover.json'), JSON.stringify({
+      peers: [{ name: 'p1', baseUrl: 'https://p1.example.com', authToken: 'tok' }],
+    }));
+    writeFileSync(join(cfgDir, 'state', 'active.json'), JSON.stringify({
+      provider: 'primary',
+      account: 'oauth:foo',
+      connection: null,
+      reason: 'on_primary',
+      at: new Date().toISOString(),
+    }));
+
+    const { resolveProvider } = await import('../../../lib/failover/active.js');
+    const r = await resolveProvider({ isInteractive: true });
+    // Interactive + primary state file → stay on primary. No auto-promote.
+    assert.equal(r.provider, 'primary');
+    assert.equal(r.autoPromoted, false);
+    assert.equal(r.account, 'oauth:foo');
+  });
+});

--- a/test/unit/failover/active.test.js
+++ b/test/unit/failover/active.test.js
@@ -79,7 +79,8 @@ describe('failover/active.js — resolveProvider (non-TTY auto-promote)', () => 
     writeFileSync(join(cfgDir, 'state', 'active.json'), JSON.stringify({
       provider: 'custom:p2',
       account: null,
-      connection: { baseUrl: 'https://p2.example.com', token: 'tok-p2', model: 'auto' },
+      // Token-free public projection — AGE-71 writes the public form to disk.
+      connection: { baseUrl: 'https://p2.example.com', model: 'auto', peer: 'p2' },
       reason: 'monitor_decision',
       at: new Date().toISOString(),
     }));
@@ -88,6 +89,7 @@ describe('failover/active.js — resolveProvider (non-TTY auto-promote)', () => 
     const r = await resolveProvider({ isInteractive: false });
     assert.equal(r.autoPromoted, false);
     assert.equal(r.provider, 'custom:p2');
+    // Token is hydrated at spawn time from failover.json — must NOT live on disk.
     assert.equal(r.connection.token, 'tok-p2');
   });
 

--- a/test/unit/failover/config-account.test.js
+++ b/test/unit/failover/config-account.test.js
@@ -1,0 +1,54 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { setAccountThresholds, clearAccountThresholds, loadConfig } from '../../../lib/config.js';
+import { tmpHome, restoreHome } from '../../helpers/temp-home.js';
+
+describe('config.js — per-account failover thresholds', () => {
+  before(() => tmpHome());
+  after(() => restoreHome());
+
+  it('setAccountThresholds writes per-account thresholds', () => {
+    saveTestConfig({ accounts: [{ name: 'foo', configDir: '/tmp/profiles/foo' }] });
+    setAccountThresholds('foo', { switch_at: 60, switch_back_at: 30 });
+    const account = loadConfig().accounts.find((a) => a.name === 'foo');
+    assert.deepEqual(account.thresholds, { switch_at: 60, switch_back_at: 30 });
+  });
+
+  it('setAccountThresholds merges into existing thresholds (one key at a time)', () => {
+    saveTestConfig({ accounts: [{ name: 'foo', configDir: '/tmp/profiles/foo' }] });
+    setAccountThresholds('foo', { switch_at: 60, switch_back_at: 30 });
+    setAccountThresholds('foo', { switch_back_at: 20 });
+    const account = loadConfig().accounts.find((a) => a.name === 'foo');
+    assert.deepEqual(account.thresholds, { switch_at: 60, switch_back_at: 20 });
+  });
+
+  it('clearAccountThresholds reverts to global', () => {
+    saveTestConfig({ accounts: [{ name: 'foo', configDir: '/tmp/profiles/foo' }] });
+    setAccountThresholds('foo', { switch_at: 60 });
+    clearAccountThresholds('foo');
+    const account = loadConfig().accounts.find((a) => a.name === 'foo');
+    assert.equal(account.thresholds, undefined);
+  });
+
+  it('validates threshold values', () => {
+    saveTestConfig({ accounts: [{ name: 'foo', configDir: '/tmp/profiles/foo' }] });
+    assert.throws(() => setAccountThresholds('foo', { switch_at: 'abc' }), /integer/);
+    assert.throws(() => setAccountThresholds('foo', { switch_at: 150 }), /0 and 100/);
+    assert.throws(() => setAccountThresholds('foo', { switch_at: -1 }), /0 and 100/);
+    assert.throws(() => setAccountThresholds('foo', { switch_at: 1.5 }), /integer/);
+  });
+
+  it('rejects unknown accounts', () => {
+    saveTestConfig({ accounts: [{ name: 'foo', configDir: '/tmp/profiles/foo' }] });
+    assert.throws(() => setAccountThresholds('nonexistent', { switch_at: 60 }), /not found/);
+  });
+});
+
+function saveTestConfig(config) {
+  const dir = join(process.env.HOME, '.claude-nonstop');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'config.json'), JSON.stringify(config, null, 2));
+}

--- a/test/unit/failover/config.test.js
+++ b/test/unit/failover/config.test.js
@@ -1,0 +1,84 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+
+import { loadFailoverConfig } from '../../../lib/failover/monitor.js';
+
+/**
+ * Tests for the config schema and threshold keys.
+ *
+ * We don't write to the real ~/.claude-nonstop/failover.json in tests — we
+ * pass an explicit configPath and use tmpdir.
+ */
+describe('failover/monitor.js — loadFailoverConfig', () => {
+  let dir;
+  let cfgPath;
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cns-failover-cfg-'));
+    cfgPath = join(dir, 'failover.json');
+  });
+
+  after(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  });
+
+  it('returns defaults when file does not exist', () => {
+    const cfg = loadFailoverConfig('/tmp/cns-does-not-exist.json');
+    assert.equal(cfg.thresholds.switch_at, 80);
+    assert.equal(cfg.thresholds.switch_back_at, 50);
+    assert.deepEqual(cfg.peers, []);
+  });
+
+  it('accepts new (switch_at / switch_back_at) keys', () => {
+    writeFileSync(cfgPath, JSON.stringify({
+      peers: [{ name: 'p1', baseUrl: 'https://p1.example.com' }],
+      thresholds: { switch_at: 70, switch_back_at: 30, recheck_interval_seconds: 120 },
+    }));
+    const cfg = loadFailoverConfig(cfgPath);
+    assert.equal(cfg.thresholds.switch_at, 70);
+    assert.equal(cfg.thresholds.switch_back_at, 30);
+    assert.equal(cfg.thresholds.recheck_interval_seconds, 120);
+    assert.equal(cfg.peers.length, 1);
+  });
+
+  it('translates legacy keys (switch_to_fallback_at → switch_at)', () => {
+    writeFileSync(cfgPath, JSON.stringify({
+      fallback: { kind: 'custom_endpoint', baseUrl: 'https://fb.example.com' },
+      thresholds: { switch_to_fallback_at: 90, switch_back_at: 60 },
+    }));
+    const cfg = loadFailoverConfig(cfgPath);
+    assert.equal(cfg.thresholds.switch_at, 90);
+    assert.equal(cfg.thresholds.switch_back_at, 60);
+  });
+
+  it('mixed legacy + new keys: new wins when both present', () => {
+    writeFileSync(cfgPath, JSON.stringify({
+      thresholds: { switch_to_fallback_at: 90, switch_at: 70 },
+    }));
+    const cfg = loadFailoverConfig(cfgPath);
+    // new key takes precedence
+    assert.equal(cfg.thresholds.switch_at, 70);
+  });
+
+  it('falls back to defaults on parse error', () => {
+    writeFileSync(cfgPath, 'not json {{{');
+    const cfg = loadFailoverConfig(cfgPath);
+    assert.equal(cfg.thresholds.switch_at, 80);
+  });
+
+  it('per-peer thresholds survive load', () => {
+    writeFileSync(cfgPath, JSON.stringify({
+      peers: [
+        { name: 'tight', baseUrl: 'https://t.example.com', thresholds: { switch_at: 50, switch_back_at: 20 } },
+        { name: 'loose', baseUrl: 'https://l.example.com', thresholds: { switch_at: 95 } },
+      ],
+    }));
+    const cfg = loadFailoverConfig(cfgPath);
+    assert.deepEqual(cfg.peers[0].thresholds, { switch_at: 50, switch_back_at: 20 });
+    assert.deepEqual(cfg.peers[1].thresholds, { switch_at: 95 });
+  });
+});

--- a/test/unit/failover/monitor.test.js
+++ b/test/unit/failover/monitor.test.js
@@ -152,6 +152,44 @@ describe('failover/monitor.js — decide (peer → primary)', () => {
     assert.ok(r);
     assert.equal(r.target, 'primary');
   });
+
+  it('honors per-peer switch_back_at when bestPeer is null on switch-back (AGE-69)', () => {
+    // Regression for AGE-69: getBestProviderOrNull sets bestPeer=null when any
+    // OAuth account is below threshold (the switch-back case). The override must
+    // still be readable via the peersByName lookup the monitor passes in.
+    const peersByName = new Map([
+      ['p1', peer('p1', { thresholds: { switch_back_at: 20 } })],
+    ]);
+    const r = decide(
+      'custom:p1',
+      {
+        best: oauthReading('a', 30),
+        bestPeer: null, // OAuth recovered → pool result has no peer
+        all: [{ name: 'oauth:a', percent: 30 }],
+      },
+      THRESHOLDS,
+      { peersByName },
+    );
+    assert.equal(r, null, '30 > 20 → stay on peer despite OAuth recovered');
+  });
+
+  it('falls back to global switch_back_at when peer has no override', () => {
+    const peersByName = new Map([
+      ['p1', peer('p1')], // no thresholds override
+    ]);
+    const r = decide(
+      'custom:p1',
+      {
+        best: oauthReading('a', 40),
+        bestPeer: null,
+        all: [{ name: 'oauth:a', percent: 40 }],
+      },
+      THRESHOLDS, // global switch_back_at = 50
+      { peersByName },
+    );
+    assert.ok(r);
+    assert.equal(r.target, 'primary');
+  });
 });
 
 describe('failover/monitor.js — decide (no OAuth accounts)', () => {

--- a/test/unit/failover/monitor.test.js
+++ b/test/unit/failover/monitor.test.js
@@ -1,0 +1,193 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { decide } from '../../../lib/failover/monitor.js';
+import { CustomEndpointProvider } from '../../../lib/failover/provider.js';
+
+const THRESHOLDS = { switch_at: 80, switch_back_at: 50 };
+
+function peer(name, opts = {}) {
+  const p = new CustomEndpointProvider({
+    name,
+    baseUrl: `https://${name}.example.com`,
+    token: 'tok',
+    thresholds: opts.thresholds,
+  });
+  p.isHealthy = async () => true;
+  return p;
+}
+
+function oauthReading(name, percent) {
+  return {
+    provider: { name: () => `oauth:${name}` },
+    reading: { percent, error: null },
+  };
+}
+
+describe('failover/monitor.js — decide (primary → peer)', () => {
+  it('stays on primary when best OAuth is below threshold', () => {
+    const r = decide(
+      'primary',
+      { best: oauthReading('a', 30), bestPeer: null, all: [{ name: 'oauth:a', percent: 30 }] },
+      THRESHOLDS,
+    );
+    assert.equal(r, null);
+  });
+
+  it('switches to peer when best OAuth is at/above switch_at', () => {
+    const r = decide(
+      'primary',
+      {
+        best: oauthReading('a', 85),
+        bestPeer: peer('p1'),
+        all: [{ name: 'oauth:a', percent: 85 }],
+      },
+      THRESHOLDS,
+    );
+    assert.ok(r);
+    assert.equal(r.target, 'custom:p1');
+    assert.equal(r.peer, 'custom:p1');
+    assert.deepEqual(r.connection.baseUrl, 'https://p1.example.com');
+  });
+
+  it('switches to peer when ALL OAuth accounts are erroring', () => {
+    const r = decide(
+      'primary',
+      {
+        best: null,
+        bestPeer: peer('p1'),
+        all: [{ name: 'oauth:a', percent: null, error: 'auth_401' }],
+      },
+      THRESHOLDS,
+    );
+    assert.ok(r);
+    assert.equal(r.target, 'custom:p1');
+  });
+
+  it('returns null when peer is unhealthy (no place to go)', () => {
+    const r = decide(
+      'primary',
+      {
+        best: oauthReading('a', 99),
+        bestPeer: null,
+        all: [{ name: 'oauth:a', percent: 99 }],
+      },
+      THRESHOLDS,
+    );
+    assert.equal(r, null);
+  });
+
+  it('honors per-account switch_at (looser threshold doesn\'t trigger)', () => {
+    // OAuth account "loose" has its own switch_at=95; at 85% it's still healthy.
+    // pool.js enforces per-account thresholds; decide() only sees accounts that
+    // already passed pickBestOAuth. We simulate that here by passing a healthy
+    // best — there is no candidate to switch TO so decide returns null.
+    const r = decide(
+      'primary',
+      {
+        best: { provider: { name: () => 'oauth:loose' }, reading: { percent: 85, error: null } },
+        bestPeer: null, // pool already filtered out exhausted accounts; no peer fallback here
+        all: [{ name: 'oauth:loose', percent: 85 }],
+      },
+      THRESHOLDS,
+    );
+    assert.equal(r, null);
+  });
+});
+
+describe('failover/monitor.js — decide (peer → primary)', () => {
+  it('switches back to primary when best OAuth drops below switch_back_at', () => {
+    const r = decide(
+      'custom:p1',
+      {
+        best: oauthReading('a', 30),
+        bestPeer: peer('p1'),
+        all: [{ name: 'oauth:a', percent: 30 }],
+      },
+      THRESHOLDS,
+    );
+    assert.ok(r);
+    assert.equal(r.target, 'primary');
+    assert.equal(r.account, 'oauth:a');
+  });
+
+  it('stays on peer when best OAuth is between switch_back_at and switch_at', () => {
+    const r = decide(
+      'custom:p1',
+      {
+        best: oauthReading('a', 65),
+        bestPeer: peer('p1'),
+        all: [{ name: 'oauth:a', percent: 65 }],
+      },
+      THRESHOLDS,
+    );
+    assert.equal(r, null);
+  });
+
+  it('honors per-peer switch_back_at override (looser hysteresis)', () => {
+    // Peer has its own switch_back_at=20 — only switch back when OAuth < 20%.
+    const r = decide(
+      'custom:p1',
+      {
+        best: oauthReading('a', 30),
+        bestPeer: peer('p1', { thresholds: { switch_back_at: 20 } }),
+        all: [{ name: 'oauth:a', percent: 30 }],
+      },
+      THRESHOLDS,
+    );
+    assert.equal(r, null); // 30 > 20, so we stay on the peer
+  });
+
+  it('honors per-peer switch_back_at override (tighter hysteresis)', () => {
+    // Peer has its own switch_back_at=80 — switch back when OAuth < 80%.
+    const r = decide(
+      'custom:p1',
+      {
+        best: oauthReading('a', 60),
+        bestPeer: peer('p1', { thresholds: { switch_back_at: 80 } }),
+        all: [{ name: 'oauth:a', percent: 60 }],
+      },
+      THRESHOLDS,
+    );
+    assert.ok(r);
+    assert.equal(r.target, 'primary');
+  });
+});
+
+describe('failover/monitor.js — decide (no OAuth accounts)', () => {
+  it('switches to peer when there are no OAuth accounts at all', () => {
+    const r = decide(
+      'primary',
+      {
+        best: null,
+        bestPeer: peer('p1'),
+        all: [],
+      },
+      THRESHOLDS,
+    );
+    assert.ok(r);
+    assert.equal(r.target, 'custom:p1');
+  });
+
+  it('stays put when no OAuth and already on a peer', () => {
+    const r = decide(
+      'custom:p1',
+      { best: null, bestPeer: peer('p1'), all: [] },
+      THRESHOLDS,
+    );
+    assert.equal(r, null);
+  });
+});
+
+describe('failover/monitor.js — legacy "fallback" / "peer:" provider strings', () => {
+  it('legacy "fallback" provider is treated as "on custom"', () => {
+    // Normalizes to "fallback"; anything not "primary" is treated as on-custom.
+    const r = decide(
+      'fallback',
+      { best: oauthReading('a', 80), bestPeer: peer('p1'), all: [{ name: 'oauth:a', percent: 80 }] },
+      THRESHOLDS,
+    );
+    // 80 > switch_back_at=50 → no switch back; stay on legacy fallback
+    assert.equal(r, null);
+  });
+});

--- a/test/unit/failover/pool.test.js
+++ b/test/unit/failover/pool.test.js
@@ -191,4 +191,39 @@ describe('failover/pool.js — getBestProviderOrNull', () => {
     // bestPeer is evaluated only when best is null
     // shape check is sufficient for this integration-level test
   });
+
+  it('probes peer health in `all` summary and reports unhealthy (AGE-72)', async () => {
+    globalThis.fetch = async (url) => {
+      // First call is OAuth usage (we don't care about that for this test).
+      // Subsequent calls target /v1/models — make the second peer unreachable.
+      const u = String(url);
+      if (u.includes('/v1/models') && u.includes('p1.example.com')) {
+        return new Response('', { status: 502 });
+      }
+      if (u.includes('/v1/models') && u.includes('p2.example.com')) {
+        return new Response('{}', { status: 200 });
+      }
+      // OAuth usage endpoints return zero util to keep the OAuth path quiet.
+      return new Response('{"five_hour":{"utilization":0}}', { status: 200 });
+    };
+
+    const r = await getBestProviderOrNull(
+      { switch_at: 80, switch_back_at: 50 },
+      {
+        peers: [
+          { name: 'p1', baseUrl: 'https://p1.example.com', authToken: 'tok-1' },
+          { name: 'p2', baseUrl: 'https://p2.example.com', authToken: 'tok-2' },
+        ],
+      },
+    );
+
+    const p1Summary = r.all.find((a) => a.name === 'custom:p1');
+    const p2Summary = r.all.find((a) => a.name === 'custom:p2');
+    assert.ok(p1Summary, 'p1 must appear in summary');
+    assert.ok(p2Summary, 'p2 must appear in summary');
+    assert.equal(p1Summary.healthy, false, 'p1 must be flagged unhealthy');
+    assert.equal(p1Summary.error, 'unhealthy');
+    assert.equal(p2Summary.healthy, true);
+    assert.equal(p2Summary.error, null);
+  });
 });

--- a/test/unit/failover/pool.test.js
+++ b/test/unit/failover/pool.test.js
@@ -1,0 +1,194 @@
+import { describe, it, before, after, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { pickBestOAuth, pickBestPeer, buildCustomPeers, getBestProviderOrNull } from '../../../lib/failover/pool.js';
+import { OAuthProvider, CustomEndpointProvider } from '../../../lib/failover/provider.js';
+
+/**
+ * Tests for the unified pool. We stub `loadConfig()` via `mock.module` so we
+ * don't touch the real ~/.claude-nonstop/config.json. The pool reads it once
+ * via `buildAllOAuthProviders()` — we route that through a fake config.
+ *
+ * Because v0.4.0 uses ESM, we patch loadConfig at runtime by overriding the
+ * exported function through dependency injection in pool.js. To keep this
+ * test self-contained, we use the readAllUtilizations / pickBestOAuth /
+ * pickBestPeer / buildCustomPeers functions directly with hand-rolled
+ * provider instances.
+ */
+
+describe('failover/pool.js — pickBestOAuth', () => {
+  const mk = (name, percent, opts = {}) => ({
+    provider: new OAuthProvider({
+      name,
+      configDir: `/tmp/${name}`,
+      getToken: () => opts.token === null ? null : 'tok',
+      thresholds: opts.thresholds,
+    }),
+    reading: opts.error
+      ? { percent: null, error: opts.error }
+      : { percent, error: null },
+  });
+
+  it('returns the lowest-utilization OAuth account', () => {
+    const best = pickBestOAuth([mk('a', 30), mk('b', 10), mk('c', 70)], { switch_at: 80 });
+    assert.equal(best.provider.name(), 'oauth:b');
+  });
+
+  it('skips accounts with usage errors (treated as 100%)', () => {
+    const best = pickBestOAuth(
+      [mk('a', 5), mk('b', null, { error: 'auth_401' })],
+      { switch_at: 80 },
+    );
+    assert.equal(best.provider.name(), 'oauth:a');
+  });
+
+  it('returns null when every account is at/above threshold', () => {
+    const best = pickBestOAuth([mk('a', 80), mk('b', 90)], { switch_at: 80 });
+    assert.equal(best, null);
+  });
+
+  it('honors per-account switch_at override', () => {
+    const accounts = [
+      mk('tight', 30, { thresholds: { switch_at: 25 } }),
+      mk('loose', 50),
+    ];
+    // tight has its own switch_at=25, so even at 30% it's "exhausted"
+    // loose is at 50% with global switch_at=80 → still healthy
+    const best = pickBestOAuth(accounts, { switch_at: 80 });
+    // All accounts were filtered out by per-account threshold; pool returns null
+    // (the caller should switch to a peer in that case).
+    assert.equal(best, null);
+  });
+
+  it('prefers unknown (null) percent over known-exhausted', () => {
+    const best = pickBestOAuth(
+      [mk('a', 95), mk('b', null, { token: 'tok' })], // b has token but no reading yet
+      { switch_at: 80 },
+    );
+    assert.equal(best.provider.name(), 'oauth:b');
+  });
+
+  it('returns null when all accounts have errors', () => {
+    const best = pickBestOAuth(
+      [mk('a', null, { error: 'auth_401' }), mk('b', null, { error: 'no_token' })],
+      { switch_at: 80 },
+    );
+    assert.equal(best, null);
+  });
+});
+
+describe('failover/pool.js — pickBestPeer', () => {
+  function healthyPeer(name, baseUrl, opts = {}) {
+    const p = new CustomEndpointProvider({ name, baseUrl, token: 'tok', thresholds: opts.thresholds });
+    p.isHealthy = async () => true;
+    return p;
+  }
+  function unhealthyPeer(name, baseUrl) {
+    const p = new CustomEndpointProvider({ name, baseUrl, token: 'tok' });
+    p.isHealthy = async () => false;
+    return p;
+  }
+
+  it('returns null when no peers', async () => {
+    const r = await pickBestPeer([], { switch_at: 80 });
+    assert.equal(r, null);
+  });
+
+  it('returns the first healthy peer', async () => {
+    const peers = [
+      unhealthyPeer('down', 'https://down.example.com'),
+      healthyPeer('up', 'https://up.example.com'),
+    ];
+    const r = await pickBestPeer(peers, { switch_at: 80 });
+    assert.equal(r.name(), 'custom:up');
+  });
+
+  it('orders peers by per-account switch_at ascending', async () => {
+    const peers = [
+      healthyPeer('loose', 'https://loose.example.com', { thresholds: { switch_at: 90 } }),
+      healthyPeer('tight', 'https://tight.example.com', { thresholds: { switch_at: 30 } }),
+    ];
+    const r = await pickBestPeer(peers, { switch_at: 80 });
+    // tight activates earliest (30) → wins
+    assert.equal(r.name(), 'custom:tight');
+  });
+
+  it('falls back to global switch_at when peer has no override', async () => {
+    const peers = [
+      healthyPeer('a', 'https://a.example.com'), // global 80
+      healthyPeer('b', 'https://b.example.com', { thresholds: { switch_at: 60 } }),
+    ];
+    const r = await pickBestPeer(peers, { switch_at: 80 });
+    assert.equal(r.name(), 'custom:b');
+  });
+
+  it('skips unhealthy peers even if their threshold fires earliest', async () => {
+    const peers = [
+      unhealthyPeer('tight-down', 'https://td.example.com', { thresholds: { switch_at: 10 } }),
+      healthyPeer('loose-up', 'https://lu.example.com'),
+    ];
+    const r = await pickBestPeer(peers, { switch_at: 80 });
+    assert.equal(r.name(), 'custom:loose-up');
+  });
+});
+
+describe('failover/pool.js — buildCustomPeers', () => {
+  before(() => {
+    // Stub env var so tests don't read the host machine's systemd unit
+    process.env.TEST_TOKEN = 'sk-test-from-env';
+  });
+  after(() => {
+    delete process.env.TEST_TOKEN;
+  });
+
+  it('builds peers from explicit peers array', () => {
+    const cfg = {
+      peers: [
+        { name: 'p1', baseUrl: 'https://p1.example.com', authToken: 'sk-p1' },
+        { name: 'p2', baseUrl: 'https://p2.example.com', authTokenEnv: 'TEST_TOKEN', thresholds: { switch_at: 60 } },
+      ],
+    };
+    const peers = buildCustomPeers(cfg);
+    assert.equal(peers.length, 2);
+    assert.equal(peers[0].name(), 'custom:p1');
+    assert.equal(peers[0].getConnectionInfo().token, 'sk-p1');
+    assert.equal(peers[1].getConnectionInfo().token, 'sk-test-from-env');
+    assert.deepEqual(peers[1].thresholdOverrides(), { switch_at: 60 });
+  });
+
+  it('promotes legacy single fallback into the peers list', () => {
+    const cfg = {
+      fallback: { kind: 'custom_endpoint', baseUrl: 'https://fb.example.com', authToken: 'sk-fb' },
+    };
+    const peers = buildCustomPeers(cfg);
+    assert.equal(peers.length, 1);
+    assert.equal(peers[0].name(), 'custom:_fallback');
+  });
+
+  it('skips peers missing required fields', () => {
+    const cfg = { peers: [{ name: 'p1' }, { baseUrl: 'https://x.example.com' }, { name: 'p2', baseUrl: 'https://p2.example.com' }] };
+    const peers = buildCustomPeers(cfg);
+    assert.equal(peers.length, 1);
+    assert.equal(peers[0].name(), 'custom:p2');
+  });
+});
+
+describe('failover/pool.js — getBestProviderOrNull', () => {
+  it('returns valid shape with all, best, bestPeer fields', async () => {
+    // getBestProviderOrNull reads real OAuth accounts from config. In the test
+    // environment, the real config has OAuth accounts (default, rahima). We only
+    // assert the contract shape — not specific OAuth readings.
+    const r = await getBestProviderOrNull(
+      { switch_at: 80, switch_back_at: 50 },
+      { peers: [{ name: 'p1', baseUrl: 'https://p1.example.com', authToken: 'tok' }] },
+    );
+    assert.ok(Array.isArray(r.all));
+    // best is either a reading or null (depends on server config)
+    assert.ok(r.best === null || typeof r.best === 'object');
+    // bestPeer is evaluated only when best is null
+    // shape check is sufficient for this integration-level test
+  });
+});

--- a/test/unit/failover/provider.test.js
+++ b/test/unit/failover/provider.test.js
@@ -1,0 +1,141 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { OAuthProvider, CustomEndpointProvider } from '../../../lib/failover/provider.js';
+
+/**
+ * Stub token resolver. Returns whatever token was registered for the
+ * configDir, or null if none. Lets OAuthProvider think it has credentials
+ * without going near the OS keychain.
+ */
+function makeTokenStore(tokens) {
+  return (configDir) => tokens[configDir] ?? null;
+}
+
+describe('failover/provider.js — OAuthProvider', () => {
+  it('names itself "oauth:<name>"', () => {
+    const p = new OAuthProvider({ name: 'rahima', configDir: '/tmp/rahima', getToken: () => 'tok' });
+    assert.equal(p.kind(), 'oauth');
+    assert.equal(p.name(), 'oauth:rahima');
+    assert.deepEqual(p.thresholdOverrides(), null);
+  });
+
+  it('exposes per-account thresholds', () => {
+    const p = new OAuthProvider({
+      name: 'a',
+      configDir: '/tmp/a',
+      getToken: () => 'tok',
+      thresholds: { switch_at: 50, switch_back_at: 20 },
+    });
+    assert.deepEqual(p.thresholdOverrides(), { switch_at: 50, switch_back_at: 20 });
+  });
+
+  it('reports no_token when token is missing', async () => {
+    const p = new OAuthProvider({ name: 'a', configDir: '/tmp/a', getToken: () => null });
+    const u = await p.getUtilization();
+    assert.equal(u.error, 'no_token');
+    assert.equal(u.percent, null);
+  });
+});
+
+describe('failover/provider.js — CustomEndpointProvider', () => {
+  it('names itself "custom:<name>" and reports kind', () => {
+    const p = new CustomEndpointProvider({
+      name: 'proxy1',
+      baseUrl: 'https://proxy.example.com',
+      token: 'tok',
+    });
+    assert.equal(p.kind(), 'custom_endpoint');
+    assert.equal(p.name(), 'custom:proxy1');
+    assert.deepEqual(p.thresholdOverrides(), null);
+  });
+
+  it('exposes per-account thresholds', () => {
+    const p = new CustomEndpointProvider({
+      name: 'proxy2',
+      baseUrl: 'https://proxy2.example.com',
+      token: 'tok',
+      thresholds: { switch_at: 70, switch_back_at: 30 },
+    });
+    assert.deepEqual(p.thresholdOverrides(), { switch_at: 70, switch_back_at: 30 });
+  });
+
+  it('reports utilization 0 with unknown flag (custom endpoints have no Anthropic-side quota)', async () => {
+    const p = new CustomEndpointProvider({
+      name: 'p',
+      baseUrl: 'https://p.example.com',
+      token: 'tok',
+    });
+    const u = await p.getUtilization();
+    assert.equal(u.percent, 0);
+    assert.equal(u.error, null);
+    assert.equal(u.unknown, true);
+  });
+
+  it('exposes connection info for env-var injection', () => {
+    const p = new CustomEndpointProvider({
+      name: 'p',
+      baseUrl: 'https://p.example.com/',
+      token: 'sk-test',
+      model: 'claude-sonnet-4-5',
+    });
+    const info = p.getConnectionInfo();
+    assert.equal(info.baseUrl, 'https://p.example.com'); // trailing slash stripped
+    assert.equal(info.token, 'sk-test');
+    assert.equal(info.model, 'claude-sonnet-4-5');
+  });
+
+  it('isHealthy uses GET /v1/models with Bearer token', async () => {
+    let capturedUrl, capturedHeaders;
+    globalThis.fetch = async (url, init) => {
+      capturedUrl = url;
+      capturedHeaders = init?.headers ?? {};
+      return new Response('', { status: 200 });
+    };
+    const p = new CustomEndpointProvider({
+      name: 'p',
+      baseUrl: 'https://p.example.com',
+      token: 'tok',
+    });
+    const ok = await p.isHealthy();
+    assert.equal(ok, true);
+    assert.equal(capturedUrl, 'https://p.example.com/v1/models');
+    assert.equal(capturedHeaders.Authorization, 'Bearer tok');
+  });
+
+  it('isHealthy caches for 30s', async () => {
+    let calls = 0;
+    globalThis.fetch = async () => { calls++; return new Response('', { status: 200 }); };
+    const p = new CustomEndpointProvider({
+      name: 'p',
+      baseUrl: 'https://p.example.com',
+      token: 'tok',
+    });
+    await p.isHealthy();
+    await p.isHealthy();
+    await p.isHealthy();
+    assert.equal(calls, 1);
+  });
+
+  it('isHealthy returns false on non-2xx', async () => {
+    globalThis.fetch = async () => new Response('', { status: 502 });
+    const p = new CustomEndpointProvider({
+      name: 'p',
+      baseUrl: 'https://p.example.com',
+      token: 'tok',
+    });
+    const ok = await p.isHealthy();
+    assert.equal(ok, false);
+  });
+
+  it('isHealthy returns false on fetch error', async () => {
+    globalThis.fetch = async () => { throw new Error('ECONNREFUSED'); };
+    const p = new CustomEndpointProvider({
+      name: 'p',
+      baseUrl: 'https://p.example.com',
+      token: 'tok',
+    });
+    const ok = await p.isHealthy();
+    assert.equal(ok, false);
+  });
+});

--- a/test/unit/failover/provider.test.js
+++ b/test/unit/failover/provider.test.js
@@ -138,4 +138,20 @@ describe('failover/provider.js — CustomEndpointProvider', () => {
     const ok = await p.isHealthy();
     assert.equal(ok, false);
   });
+
+  it('getPublicConnectionInfo strips the token (AGE-71)', () => {
+    const p = new CustomEndpointProvider({
+      name: 'p',
+      baseUrl: 'https://p.example.com',
+      token: 'secret-token-do-not-leak',
+      model: 'claude-sonnet-4-5',
+    });
+    const pub = p.getPublicConnectionInfo();
+    assert.equal(pub.baseUrl, 'https://p.example.com');
+    assert.equal(pub.model, 'claude-sonnet-4-5');
+    assert.equal(pub.peer, 'p');
+    assert.ok(!('token' in pub), 'public form must not carry a token key');
+    const raw = JSON.stringify(pub);
+    assert.ok(!raw.includes('secret-token'), 'public form must not contain token bytes');
+  });
 });

--- a/test/unit/lib/config.test.js
+++ b/test/unit/lib/config.test.js
@@ -13,9 +13,14 @@ import {
   getAccounts,
   setAccountPriority,
   clearAccountPriority,
-  DEFAULT_CLAUDE_DIR,
-  CONFIG_DIR,
+  DEFAULT_CLAUDE_DIR as DEFAULT_CLAUDE_DIR_FN,
+  CONFIG_DIR as CONFIG_DIR_FN,
 } from '../../../lib/config.js';
+
+// CONFIG_DIR and DEFAULT_CLAUDE_DIR changed from constants to functions in
+// v0.4.1 for test-isolation support. Coerce them to strings for existing tests.
+const CONFIG_DIR = typeof CONFIG_DIR_FN === 'function' ? CONFIG_DIR_FN() : CONFIG_DIR_FN;
+const DEFAULT_CLAUDE_DIR = typeof DEFAULT_CLAUDE_DIR_FN === 'function' ? DEFAULT_CLAUDE_DIR_FN() : DEFAULT_CLAUDE_DIR_FN;
 
 describe('validateAccountName', () => {
   it('accepts valid names', () => {


### PR DESCRIPTION
## Summary

Addresses the three review-blocking findings raised on #24:

- **AGE-71** — `CustomEndpointProvider.getPublicConnectionInfo()` returns only `{baseUrl, model, peer}`; `monitor.tick` writes the public form to `state.connection`; `active.resolveProvider` re-hydrates the token at spawn time from `failover.json` so the bearer never lives on disk.
- **AGE-72** — `getBestProviderOrNull` now probes each peer's `isHealthy()` in parallel and surfaces `{healthy, error:'unhealthy'}` in the `all` summary, so `failover status` / `dry-run` reflect real reachability instead of the hardcoded `{percent:0, error:null, isPeer:true}`.
- **AGE-69** — `decide()` now accepts a `peersByName` map so the switch-back path can resolve per-peer `switch_back_at` from the *current* peer (bestPeer is null once OAuth recovers — the regression the child issue flagged).

## Verification

```
node --test test/unit/failover/active.test.js     → 6/6 pass
node --test test/unit/failover/config-account.test.js → 5/5 pass
node --test test/unit/failover/config.test.js    → 6/6 pass
node --test test/unit/failover/monitor.test.js   → 14/14 pass (2 new)
node --test test/unit/failover/pool.test.js      → 16/16 pass (1 new)
node --test test/unit/failover/provider.test.js  → 12/12 pass (1 new)
```

The 8 unrelated `npm test` failures (`@slack/bolt` missing, keychain macOS paths, rate-limit-detection, runner-utils) are pre-existing on main.

## Out of scope

No changes to:
- Backwards compat for the legacy single `fallback` entry (preserved via `normalizePeers`).
- The `ANTHROPIC_AUTH_TOKEN` env-var convention.
- The OAuth pool selector (`claude-switcher`).