### PR TITLE
Add Fable weekly column + reset datetimes to status, render deterministically

### DIFF
--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -439,7 +439,18 @@ async function cmdStatus() {
     const best = pickBestAccount(withUsage);
     const bestName = best?.account?.name;
 
-    for (const account of withUsage) {
+    // Render in a deterministic order: by priority ascending (1 = highest),
+    // accounts without a priority last, ties broken by name. This keeps the
+    // table stable across runs regardless of config.json insertion order or
+    // which account happens to be "best".
+    const ordered = [...withUsage].sort((a, b) => {
+      const pa = a.priority ?? Number.POSITIVE_INFINITY;
+      const pb = b.priority ?? Number.POSITIVE_INFINITY;
+      if (pa !== pb) return pa - pb;
+      return a.name.localeCompare(b.name);
+    });
+
+    for (const account of ordered) {
       const isBest = account.name === bestName;
       const marker = isBest ? ' <-- best' : '';
       const userInfo = formatUserInfo(profileMap[account.name] || {});
@@ -453,27 +464,16 @@ async function cmdStatus() {
         renderSpendUsage(account.usage);
       } else {
         const u = account.usage;
-        const sessionBar = makeBar(u.sessionPercent);
-        const weeklyBar = makeBar(u.weeklyPercent);
-        // Absolute reset datetime in parens (e.g. "Jul 8, 8:29 PM PDT") next to
-        // each meter, plus the relative "in Xh Ym" below for at-a-glance reading.
-        const sessionReset = u.sessionResetsAt ? ` (resets ${formatAbsoluteReset(u.sessionResetsAt)})` : '';
-        const weeklyReset = u.weeklyResetsAt ? ` (resets ${formatAbsoluteReset(u.weeklyResetsAt)})` : '';
-        console.log(`    5-hour:  ${sessionBar} ${u.sessionPercent}%${sessionReset}`);
-        console.log(`    7-day:   ${weeklyBar} ${u.weeklyPercent}%${weeklyReset}`);
-
-        // Model-scoped weekly cap (Fable). Only shown when the account reports one.
+        // Uniform window-account rows: always 5-hour, 7-day, and Fable, each as
+        // "<bar> <pct>% (resets <datetime>)". A missing reset renders "(resets —)"
+        // so the columns stay aligned and the table looks the same every run.
+        // Fable falls back to "—" when the account reports no per-model cap.
+        console.log(`    5-hour:  ${makeBar(u.sessionPercent)} ${padPct(u.sessionPercent)} (resets ${resetOrDash(u.sessionResetsAt)})`);
+        console.log(`    7-day:   ${makeBar(u.weeklyPercent)} ${padPct(u.weeklyPercent)} (resets ${resetOrDash(u.weeklyResetsAt)})`);
         if (u.fablePercent != null) {
-          const fableBar = makeBar(u.fablePercent);
-          const fableReset = u.fableResetsAt ? ` (resets ${formatAbsoluteReset(u.fableResetsAt)})` : '';
-          console.log(`    Fable:   ${fableBar} ${u.fablePercent}%${fableReset}`);
-        }
-
-        if (u.sessionResetsAt) {
-          console.log(`    Session resets: ${formatResetTime(u.sessionResetsAt)}`);
-        }
-        if (u.weeklyResetsAt) {
-          console.log(`    Weekly resets:  ${formatResetTime(u.weeklyResetsAt)}`);
+          console.log(`    Fable:   ${makeBar(u.fablePercent)} ${padPct(u.fablePercent)} (resets ${resetOrDash(u.fableResetsAt)})`);
+        } else {
+          console.log(`    Fable:   ${makeBar(0)} ${'—'.padStart(4)} (no per-model cap)`);
         }
       }
       console.log('');
@@ -1674,22 +1674,21 @@ function makeBar(percent, width = 20) {
   return `\x1b[32m${bar}\x1b[0m`; // Green
 }
 
-function formatResetTime(isoString) {
-  try {
-    const date = new Date(isoString);
-    const now = new Date();
-    const diffMs = date.getTime() - now.getTime();
+/**
+ * Right-align a percentage to a fixed width so meter values line up in the
+ * status table (e.g. "  0%", " 33%", "100%").
+ */
+function padPct(percent) {
+  return `${percent}%`.padStart(4);
+}
 
-    if (diffMs <= 0) return 'now';
-
-    const hours = Math.floor(diffMs / (1000 * 60 * 60));
-    const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-
-    if (hours > 0) return `in ${hours}h ${minutes}m`;
-    return `in ${minutes}m`;
-  } catch {
-    return isoString;
-  }
+/**
+ * Absolute reset datetime for the status table, or an em dash when the API did
+ * not report one (some accounts return null session resets). Keeps every meter
+ * row the same shape.
+ */
+function resetOrDash(isoString) {
+  return isoString ? formatAbsoluteReset(isoString) : '—';
 }
 
 /**

--- a/bin/claude-nonstop.js
+++ b/bin/claude-nonstop.js
@@ -452,16 +452,28 @@ async function cmdStatus() {
       } else if (account.usage.meterType === 'spend') {
         renderSpendUsage(account.usage);
       } else {
-        const sessionBar = makeBar(account.usage.sessionPercent);
-        const weeklyBar = makeBar(account.usage.weeklyPercent);
-        console.log(`    5-hour:  ${sessionBar} ${account.usage.sessionPercent}%`);
-        console.log(`    7-day:   ${weeklyBar} ${account.usage.weeklyPercent}%`);
+        const u = account.usage;
+        const sessionBar = makeBar(u.sessionPercent);
+        const weeklyBar = makeBar(u.weeklyPercent);
+        // Absolute reset datetime in parens (e.g. "Jul 8, 8:29 PM PDT") next to
+        // each meter, plus the relative "in Xh Ym" below for at-a-glance reading.
+        const sessionReset = u.sessionResetsAt ? ` (resets ${formatAbsoluteReset(u.sessionResetsAt)})` : '';
+        const weeklyReset = u.weeklyResetsAt ? ` (resets ${formatAbsoluteReset(u.weeklyResetsAt)})` : '';
+        console.log(`    5-hour:  ${sessionBar} ${u.sessionPercent}%${sessionReset}`);
+        console.log(`    7-day:   ${weeklyBar} ${u.weeklyPercent}%${weeklyReset}`);
 
-        if (account.usage.sessionResetsAt) {
-          console.log(`    Session resets: ${formatResetTime(account.usage.sessionResetsAt)}`);
+        // Model-scoped weekly cap (Fable). Only shown when the account reports one.
+        if (u.fablePercent != null) {
+          const fableBar = makeBar(u.fablePercent);
+          const fableReset = u.fableResetsAt ? ` (resets ${formatAbsoluteReset(u.fableResetsAt)})` : '';
+          console.log(`    Fable:   ${fableBar} ${u.fablePercent}%${fableReset}`);
         }
-        if (account.usage.weeklyResetsAt) {
-          console.log(`    Weekly resets:  ${formatResetTime(account.usage.weeklyResetsAt)}`);
+
+        if (u.sessionResetsAt) {
+          console.log(`    Session resets: ${formatResetTime(u.sessionResetsAt)}`);
+        }
+        if (u.weeklyResetsAt) {
+          console.log(`    Weekly resets:  ${formatResetTime(u.weeklyResetsAt)}`);
         }
       }
       console.log('');

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -63,6 +63,15 @@ const NO_SPEND = {
 };
 
 /**
+ * Empty model-scoped (Fable) fields — merged into error/timeout results so the
+ * return shape is uniform whether or not a scoped cap was read.
+ */
+const NO_FABLE = {
+  fablePercent: null,
+  fableResetsAt: null,
+};
+
+/**
  * Detect and normalize a spend-metered (Enterprise usage-based) payload.
  *
  * Precedence: the `spend` block is authoritative; the older `extra_usage`
@@ -135,6 +144,29 @@ export function parseSpend(data) {
 }
 
 /**
+ * Extract the model-scoped weekly limit for a given model display name from the
+ * usage payload's `limits` array. The API reports per-model weekly caps (e.g.
+ * Fable) as entries with kind `weekly_scoped` and `scope.model.display_name`.
+ * The older top-level `five_hour`/`seven_day` fields do NOT carry this, so it
+ * must be read from `limits`. Returns { percent, resetsAt } or null if absent.
+ *
+ * @param {object} data - raw usage API payload
+ * @param {string} modelName - display name to match (e.g. "Fable")
+ * @returns {{ percent: number, resetsAt: string|null }|null}
+ */
+export function parseScopedModelLimit(data, modelName) {
+  const limits = Array.isArray(data?.limits) ? data.limits : [];
+  const entry = limits.find(
+    (l) => l?.kind === 'weekly_scoped' && l?.scope?.model?.display_name === modelName
+  );
+  if (!entry) return null;
+  return {
+    percent: normalizePercent(entry.percent ?? 0),
+    resetsAt: entry.resets_at ?? null,
+  };
+}
+
+/**
  * Check usage for a single account token.
  *
  * @param {string} token - OAuth access token
@@ -164,6 +196,7 @@ export async function checkUsage(token) {
         weeklyPercent: 0,
         sessionResetsAt: null,
         weeklyResetsAt: null,
+        ...NO_FABLE,
         ...NO_SPEND,
         error: `HTTP ${res.status}`,
       };
@@ -177,6 +210,14 @@ export async function checkUsage(token) {
     // the existing window fields then.
     const spend = parseSpend(data) ?? NO_SPEND;
 
+    // Model-scoped weekly cap (e.g. Fable) lives in data.limits[], not in the
+    // top-level five_hour/seven_day fields. Null when the account has no such cap.
+    const fable = parseScopedModelLimit(data, 'Fable');
+    const fableFields = {
+      fablePercent: fable ? fable.percent : null,
+      fableResetsAt: fable ? fable.resetsAt : null,
+    };
+
     // New nested format: { five_hour: { utilization: N, resets_at: "..." }, seven_day: { ... } }
     if (data.five_hour !== undefined || data.seven_day !== undefined) {
       return {
@@ -184,6 +225,7 @@ export async function checkUsage(token) {
         weeklyPercent: normalizePercent(data.seven_day?.utilization ?? 0),
         sessionResetsAt: data.five_hour?.resets_at ?? null,
         weeklyResetsAt: data.seven_day?.resets_at ?? null,
+        ...fableFields,
         ...spend,
         error: null,
       };
@@ -195,6 +237,7 @@ export async function checkUsage(token) {
       weeklyPercent: normalizePercent(data.seven_day_utilization ?? 0),
       sessionResetsAt: data.five_hour_reset_at ?? null,
       weeklyResetsAt: data.seven_day_reset_at ?? null,
+      ...fableFields,
       ...spend,
       error: null,
     };
@@ -204,6 +247,7 @@ export async function checkUsage(token) {
       weeklyPercent: 0,
       sessionResetsAt: null,
       weeklyResetsAt: null,
+      ...NO_FABLE,
       ...NO_SPEND,
       error: error.name === 'AbortError' ? 'timeout' : error.message,
     };

--- a/test/unit/lib/usage.test.js
+++ b/test/unit/lib/usage.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizePercent, checkUsage, fetchProfile, checkAllUsage, nextMonthlyResetUTC } from '../../../lib/usage.js';
+import { normalizePercent, checkUsage, fetchProfile, checkAllUsage, nextMonthlyResetUTC, parseScopedModelLimit } from '../../../lib/usage.js';
 
 describe('normalizePercent', () => {
   it('converts 0.5 fraction to 50%', () => {
@@ -136,6 +136,72 @@ describe('checkUsage', () => {
     assert.equal(r.spendLimitMinor, null);
     assert.equal(r.spendUsedMinor, null);
     assert.equal(r.spendResetsAt, null);
+  });
+
+  it('extracts Fable-scoped weekly cap from limits[]', async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        five_hour: { utilization: 0, resets_at: '2026-07-09T03:30:00Z' },
+        seven_day: { utilization: 4, resets_at: '2026-07-14T19:00:00Z' },
+        limits: [
+          { kind: 'session', percent: 0, resets_at: '2026-07-09T03:30:00Z' },
+          { kind: 'weekly_all', percent: 4, resets_at: '2026-07-14T19:00:00Z' },
+          { kind: 'weekly_scoped', percent: 100, resets_at: '2026-07-12T19:00:00Z', scope: { model: { display_name: 'Fable' } } },
+        ],
+      }),
+    });
+    const r = await checkUsage('sk-ant-oat01-test');
+    assert.equal(r.fablePercent, 100);
+    assert.equal(r.fableResetsAt, '2026-07-12T19:00:00Z');
+  });
+
+  it('leaves Fable fields null when no scoped cap present', async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        five_hour: { utilization: 0 },
+        seven_day: { utilization: 4 },
+        limits: [{ kind: 'weekly_all', percent: 4 }],
+      }),
+    });
+    const r = await checkUsage('sk-ant-oat01-test');
+    assert.equal(r.fablePercent, null);
+    assert.equal(r.fableResetsAt, null);
+  });
+});
+
+describe('parseScopedModelLimit', () => {
+  const withFable = {
+    limits: [
+      { kind: 'weekly_all', percent: 29, resets_at: '2026-07-10T03:00:00Z' },
+      { kind: 'weekly_scoped', percent: 58, resets_at: '2026-07-10T03:00:00Z', scope: { model: { display_name: 'Fable' } } },
+    ],
+  };
+
+  it('returns percent + resetsAt for a matching scoped model', () => {
+    const r = parseScopedModelLimit(withFable, 'Fable');
+    assert.deepEqual(r, { percent: 58, resetsAt: '2026-07-10T03:00:00Z' });
+  });
+
+  it('returns null when the model is not present', () => {
+    assert.equal(parseScopedModelLimit(withFable, 'Opus'), null);
+  });
+
+  it('returns null when limits is absent or empty', () => {
+    assert.equal(parseScopedModelLimit({}, 'Fable'), null);
+    assert.equal(parseScopedModelLimit({ limits: [] }, 'Fable'), null);
+    assert.equal(parseScopedModelLimit(null, 'Fable'), null);
+  });
+
+  it('normalizes a fractional percent and tolerates a null reset', () => {
+    const data = { limits: [{ kind: 'weekly_scoped', percent: 0.42, scope: { model: { display_name: 'Fable' } } }] };
+    assert.deepEqual(parseScopedModelLimit(data, 'Fable'), { percent: 42, resetsAt: null });
+  });
+
+  it('ignores non-weekly_scoped entries that name the model', () => {
+    const data = { limits: [{ kind: 'session', percent: 99, scope: { model: { display_name: 'Fable' } } }] };
+    assert.equal(parseScopedModelLimit(data, 'Fable'), null);
   });
 });
 


### PR DESCRIPTION
## Summary

Enhances `claude-nonstop status` with per-model (Fable) weekly usage, absolute reset datetimes, and a deterministic, uniform table layout.

**Before** each meter showed only a bar + percent, with reset info split across an inline-absent format and separate relative "in Xh Ym" lines; accounts printed in config.json insertion order.

**After:**
```
  default (…) (priority: 1)
    5-hour:  ████████████████████ 100% (resets Jul 8, 8:29 PM PDT)
    7-day:   █░░░░░░░░░░░░░░░░░░░   4% (resets Jul 14, 11:59 AM PDT)
    Fable:   █░░░░░░░░░░░░░░░░░░░   7% (resets Jul 14, 11:59 AM PDT)
```

## Changes

- **New Fable row.** The per-model weekly cap is reported in the usage API's `limits[]` array as a `weekly_scoped` entry with `scope.model.display_name` — the top-level `five_hour`/`seven_day` fields don't carry it. Added `parseScopedModelLimit(data, modelName)` to `lib/usage.js` and surfaced `fablePercent`/`fableResetsAt` from `checkUsage`.
- **Reset datetimes inline.** 5-hour and 7-day now show the absolute reset instant (Pacific, DST-aware) in parens, reusing the existing `formatAbsoluteReset` helper.
- **Deterministic order.** Accounts render sorted by priority ascending (unpriorited last, ties by name), stable across runs.
- **Uniform rows.** Every window-account meter is `<bar> <pct>% (resets <datetime>)` with right-aligned percentages and `(resets —)` when the API returns a null reset. Fable shows `(no per-model cap)` when absent. Removed the redundant relative-reset lines and the now-unused `formatResetTime` helper.

## Testing

- `+7` unit tests for `parseScopedModelLimit` and the `checkUsage` Fable integration.
- Full suite green: **475 tests pass, 0 fail** (`npm test`).
- `npm run check` clean.
- Verified deterministic output across repeated runs on a 4-account setup (Max window-metered + Enterprise spend-metered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)